### PR TITLE
Add configurable API URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # 3.1.0, in progress
 
+## Added
+
+### New Configuration Options
+
+The following new options were added to the provider's configuration:
+
+* `api_url` which allows users to customize the URL to which API requests will be send. This allows users of other realms or those using proxies to use this provider.
+* `custom_app_url` which allows users to customize the app URL used for viewing resources. This is mostly for users that use SSO with SignalFx, i.e. `https://yourcompany.signalfx.com`.
+
+## Removed
+
+* The attribute `resource_url` has been removed from resources. This means that the provider will not output a URL after an `apply`, since the `url` resource is "computed" in Terraform parlance. You can, however, find the URL for any asset with `terraform show <asset name>`. For example, `terraform state show signalfx_dashboard.mydashboard1`.
+
 # 3.0.0, 2019-03-18
 
 We're jumping to a 3.0.0 version number after forking from [Yelp's SignalForm](https://github.com/Yelp/terraform-provider-signalform/), incorporating [Stripe's fork](https://github.com/stripe/terraform-provider-signalform/), and renaming to `terraform-provider-signalfx`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 3.1.0, in progress
 
+* Any use of a resource's `resource_url` should be replaced with `url`, most likely as an output value. See the Removed section below for more.
+
 ## Added
 
 ### New Configuration Options

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@
 
 The following new options were added to the provider's configuration:
 
-* `api_url` which allows users to customize the URL to which API requests will be send. This allows users of other realms or those using proxies to use this provider.
-* `custom_app_url` which allows users to customize the app URL used for viewing resources. This is mostly for users that use SSO with SignalFx, i.e. `https://yourcompany.signalfx.com`.
+* `api_url` which allows users to customize the URL to which API requests will be sent. This allows users of other realms or those using proxies to use this provider. Note you probably want to change `custom_app_url` as well!
+* `custom_app_url` which allows users to customize the app URL used for viewing resources. This is used by organizations using specific realms or those with a custom [SSO domain](https://docs.signalfx.com/en/latest/admin-guide/sso.html).
 
 ## Removed
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ This provider has the following configuration options:
 
 * `auth_token` (required) - The auth token for [authentication](https://developers.signalfx.com/basics/authentication.html)
 * `api_url` - The API URL to use for communicating with SignalFx. This is helpful for organizations who need to set their Realm or use a proxy.
-* `custom_app_url` - The application URL that users should use to interact with assets in the browser. This is used by organizations with a custom [SSO domain](https://docs.signalfx.com/en/latest/admin-guide/sso.html).
+ Note: You likely want to change `custom_app_url` too!
+* `custom_app_url` - The application URL that users should use to interact with assets in the browser. This is used by organizations using specific realms or those with a custom [SSO domain](https://docs.signalfx.com/en/latest/admin-guide/sso.html).
 
 ## Build And Install
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ Changelog is available [here](https://github.com/signalfx/terraform-provider-sig
 
 Note: If you missed running `terraform init` in an earlier step you'll likely be prompted to do that now.
 
+## Configuration
+
+This provider has the following configuration options:
+
+* `auth_token` (required) - The auth token for [authentication](https://developers.signalfx.com/basics/authentication.html)
+* `api_url` - The API URL to use for communicating with SignalFx. This is helpful for organizations who need to set their Realm or use a proxy.
+* `custom_app_url` - The application URL that users should use to interact with assets in the browser. This is used by organizations with a custom [SSO domain](https://docs.signalfx.com/en/latest/admin-guide/sso.html).
+
 ## Build And Install
 
 ### Build binary from source

--- a/signalfx/dashboard.go
+++ b/signalfx/dashboard.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	DASHBOARD_API_PATH = "/v2/dashboard"
-	DASHBOARD_APP_PATH = "/#/dashboard/"
+	DASHBOARD_APP_PATH = "/dashboard/"
 )
 
 func dashboardResource() *schema.Resource {
@@ -661,8 +661,7 @@ func dashboardCreate(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 	// Since things worked, set the URL and move on
-
-	appURL, err := buildURL(config.CustomDomain, DASHBOARD_APP_PATH+d.Id())
+	appURL, err := buildAppURL(config.CustomAppURL, DASHBOARD_APP_PATH+d.Id())
 	if err != nil {
 		return err
 	}

--- a/signalfx/dashboard.go
+++ b/signalfx/dashboard.go
@@ -10,8 +10,7 @@ import (
 )
 
 const (
-	DASHBOARD_API_URL = "https://api.signalfx.com/v2/dashboard"
-	DASHBOARD_URL     = "https://app.signalfx.com/#/dashboard/<id>"
+	DASHBOARD_API_PATH = "/v2/dashboard"
 )
 
 func dashboardResource() *schema.Resource {
@@ -27,17 +26,6 @@ func dashboardResource() *schema.Resource {
 				Type:        schema.TypeFloat,
 				Computed:    true,
 				Description: "Latest timestamp the resource was updated",
-			},
-			"resource_url": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				Default:     DASHBOARD_URL,
-				Description: "API URL of the dashboard",
-			},
-			"url": &schema.Schema{
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "URL of the dashboard",
 			},
 			"name": &schema.Schema{
 				Type:        schema.TypeString,
@@ -658,12 +646,20 @@ func dashboardCreate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Failed creating json payload: %s", err.Error())
 	}
 	log.Printf("[SignalFx] Dashboard Create Payload: %s", string(payload))
-	return resourceCreate(DASHBOARD_API_URL, config.AuthToken, payload, d)
+	url, err := buildAPIURL(config.APIURL, DASHBOARD_API_PATH)
+	if err != nil {
+		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
+	}
+	return resourceCreate(url, config.AuthToken, payload, d)
 }
 
 func dashboardRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
-	url := fmt.Sprintf("%s/%s", DASHBOARD_API_URL, d.Id())
+	path := fmt.Sprintf("%s/%s", DASHBOARD_API_PATH, d.Id())
+	url, err := buildAPIURL(config.APIURL, path)
+	if err != nil {
+		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
+	}
 
 	return resourceRead(url, config.AuthToken, d)
 }
@@ -674,14 +670,26 @@ func dashboardUpdate(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return fmt.Errorf("Failed creating json payload: %s", err.Error())
 	}
-	url := fmt.Sprintf("%s/%s", DASHBOARD_API_URL, d.Id())
+
+	path := fmt.Sprintf("%s/%s", DASHBOARD_API_PATH, d.Id())
+	url, err := buildAPIURL(config.APIURL, path)
+	if err != nil {
+		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
+	}
+
 	log.Printf("[SignalFx] Dashboard Update Payload: %s", string(payload))
 	return resourceUpdate(url, config.AuthToken, payload, d)
 }
 
 func dashboardDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
-	url := fmt.Sprintf("%s/%s", DASHBOARD_API_URL, d.Id())
+
+	path := fmt.Sprintf("%s/%s", DASHBOARD_API_PATH, d.Id())
+	url, err := buildAPIURL(config.APIURL, path)
+	if err != nil {
+		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
+	}
+
 	return resourceDelete(url, config.AuthToken, d)
 }
 

--- a/signalfx/dashboard.go
+++ b/signalfx/dashboard.go
@@ -23,15 +23,15 @@ func dashboardResource() *schema.Resource {
 				Default:     true,
 				Description: "Whether the resource in the provider and SignalFx are identical or not. Used internally for syncing.",
 			},
-			"url": &schema.Schema{
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "URL of the dashboard",
-			},
 			"last_updated": &schema.Schema{
 				Type:        schema.TypeFloat,
 				Computed:    true,
 				Description: "Latest timestamp the resource was updated",
+			},
+			"url": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "URL of the dashboard",
 			},
 			"name": &schema.Schema{
 				Type:        schema.TypeString,

--- a/signalfx/dashboard_group.go
+++ b/signalfx/dashboard_group.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
-const DASHBOARD_GROUP_API_URL = "https://api.signalfx.com/v2/dashboardgroup"
+const DASHBOARD_GROUP_API_PATH = "/v2/dashboardgroup"
 
 func dashboardGroupResource() *schema.Resource {
 	return &schema.Resource{
@@ -73,12 +73,21 @@ func dashboardgroupCreate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Failed creating json payload: %s", err.Error())
 	}
 
-	return resourceCreate(DASHBOARD_GROUP_API_URL, config.AuthToken, payload, d)
+	url, err := buildURL(config.APIURL, DASHBOARD_GROUP_API_PATH)
+	if err != nil {
+		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
+	}
+
+	return resourceCreate(url, config.AuthToken, payload, d)
 }
 
 func dashboardgroupRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
-	url := fmt.Sprintf("%s/%s", DASHBOARD_GROUP_API_URL, d.Id())
+	path := fmt.Sprintf("%s/%s", DASHBOARD_GROUP_API_PATH, d.Id())
+	url, err := buildURL(config.APIURL, path)
+	if err != nil {
+		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
+	}
 
 	return resourceRead(url, config.AuthToken, d)
 }
@@ -89,13 +98,22 @@ func dashboardgroupUpdate(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return fmt.Errorf("Failed creating json payload: %s", err.Error())
 	}
-	url := fmt.Sprintf("%s/%s", DASHBOARD_GROUP_API_URL, d.Id())
+	path := fmt.Sprintf("%s/%s", DASHBOARD_GROUP_API_PATH, d.Id())
+	url, err := buildURL(config.APIURL, path)
+	if err != nil {
+		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
+	}
 
 	return resourceUpdate(url, config.AuthToken, payload, d)
 }
 
 func dashboardgroupDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
-	url := fmt.Sprintf("%s/%s", DASHBOARD_GROUP_API_URL, d.Id())
+	path := fmt.Sprintf("%s/%s", DASHBOARD_GROUP_API_PATH, d.Id())
+	url, err := buildURL(config.APIURL, path)
+	if err != nil {
+		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
+	}
+
 	return resourceDelete(url, config.AuthToken, d)
 }

--- a/signalfx/detector.go
+++ b/signalfx/detector.go
@@ -29,6 +29,11 @@ func detectorResource() *schema.Resource {
 				Computed:    true,
 				Description: "Latest timestamp the resource was updated",
 			},
+			"url": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "URL of the detector",
+			},
 			"name": &schema.Schema{
 				Type:        schema.TypeString,
 				Required:    true,

--- a/signalfx/detector.go
+++ b/signalfx/detector.go
@@ -302,7 +302,7 @@ func detectorCreate(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return fmt.Errorf("Failed creating json payload: %s", err.Error())
 	}
-	url, err := buildAPIURL(config.APIURL, DETECTOR_API_PATH)
+	url, err := buildURL(config.APIURL, DETECTOR_API_PATH)
 	if err != nil {
 		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
 	}
@@ -313,7 +313,7 @@ func detectorCreate(d *schema.ResourceData, meta interface{}) error {
 func detectorRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 	path := fmt.Sprintf("%s/%s", DETECTOR_API_PATH, d.Id())
-	url, err := buildAPIURL(config.APIURL, path)
+	url, err := buildURL(config.APIURL, path)
 	if err != nil {
 		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
 	}
@@ -328,7 +328,7 @@ func detectorUpdate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Failed creating json payload: %s", err.Error())
 	}
 	path := fmt.Sprintf("%s/%s", DETECTOR_API_PATH, d.Id())
-	url, err := buildAPIURL(config.APIURL, path)
+	url, err := buildURL(config.APIURL, path)
 	if err != nil {
 		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
 	}
@@ -339,7 +339,7 @@ func detectorUpdate(d *schema.ResourceData, meta interface{}) error {
 func detectorDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 	path := fmt.Sprintf("%s/%s", DETECTOR_API_PATH, d.Id())
-	url, err := buildAPIURL(config.APIURL, path)
+	url, err := buildURL(config.APIURL, path)
 	if err != nil {
 		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
 	}

--- a/signalfx/detector.go
+++ b/signalfx/detector.go
@@ -12,8 +12,7 @@ import (
 )
 
 const (
-	DETECTOR_API_URL = "https://api.signalfx.com/v2/detector"
-	DETECTOR_URL     = "https://app.signalfx.com/#/detector/v2/<id>/edit"
+	DETECTOR_API_PATH = "/v2/detector"
 )
 
 func detectorResource() *schema.Resource {
@@ -29,17 +28,6 @@ func detectorResource() *schema.Resource {
 				Type:        schema.TypeFloat,
 				Computed:    true,
 				Description: "Latest timestamp the resource was updated",
-			},
-			"url": &schema.Schema{
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "Url of the detector",
-			},
-			"resource_url": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				Default:     DETECTOR_URL,
-				Description: "Base Detector url",
 			},
 			"name": &schema.Schema{
 				Type:        schema.TypeString,
@@ -314,13 +302,21 @@ func detectorCreate(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return fmt.Errorf("Failed creating json payload: %s", err.Error())
 	}
+	url, err := buildAPIURL(config.APIURL, DETECTOR_API_PATH)
+	if err != nil {
+		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
+	}
 
-	return resourceCreate(DETECTOR_API_URL, config.AuthToken, payload, d)
+	return resourceCreate(url, config.AuthToken, payload, d)
 }
 
 func detectorRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
-	url := fmt.Sprintf("%s/%s", DETECTOR_API_URL, d.Id())
+	path := fmt.Sprintf("%s/%s", DETECTOR_API_PATH, d.Id())
+	url, err := buildAPIURL(config.APIURL, path)
+	if err != nil {
+		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
+	}
 
 	return resourceRead(url, config.AuthToken, d)
 }
@@ -331,14 +327,22 @@ func detectorUpdate(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return fmt.Errorf("Failed creating json payload: %s", err.Error())
 	}
-	url := fmt.Sprintf("%s/%s", DETECTOR_API_URL, d.Id())
+	path := fmt.Sprintf("%s/%s", DETECTOR_API_PATH, d.Id())
+	url, err := buildAPIURL(config.APIURL, path)
+	if err != nil {
+		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
+	}
 
 	return resourceUpdate(url, config.AuthToken, payload, d)
 }
 
 func detectorDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
-	url := fmt.Sprintf("%s/%s", DETECTOR_API_URL, d.Id())
+	path := fmt.Sprintf("%s/%s", DETECTOR_API_PATH, d.Id())
+	url, err := buildAPIURL(config.APIURL, path)
+	if err != nil {
+		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
+	}
 
 	return resourceDelete(url, config.AuthToken, d)
 }

--- a/signalfx/detector.go
+++ b/signalfx/detector.go
@@ -13,6 +13,7 @@ import (
 
 const (
 	DETECTOR_API_PATH = "/v2/detector"
+	DETECTOR_APP_PATH = "/detector/"
 )
 
 func detectorResource() *schema.Resource {
@@ -312,7 +313,17 @@ func detectorCreate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
 	}
 
-	return resourceCreate(url, config.AuthToken, payload, d)
+	err = resourceCreate(url, config.AuthToken, payload, d)
+	if err != nil {
+		return err
+	}
+	// Since things worked, set the URL and move on
+	appURL, err := buildAppURL(config.CustomAppURL, DETECTOR_APP_PATH+d.Id())
+	if err != nil {
+		return err
+	}
+	d.Set("url", appURL)
+	return nil
 }
 
 func detectorRead(d *schema.ResourceData, meta interface{}) error {

--- a/signalfx/heatmap_chart.go
+++ b/signalfx/heatmap_chart.go
@@ -23,17 +23,6 @@ func heatmapChartResource() *schema.Resource {
 				Computed:    true,
 				Description: "Latest timestamp the resource was updated",
 			},
-			"resource_url": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				Default:     CHART_URL,
-				Description: "API URL of the chart",
-			},
-			"url": &schema.Schema{
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "URL of the chart",
-			},
 			"name": &schema.Schema{
 				Type:        schema.TypeString,
 				Required:    true,
@@ -260,12 +249,21 @@ func heatmapchartCreate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Failed creating json payload: %s", err.Error())
 	}
 
-	return resourceCreate(CHART_API_URL, config.AuthToken, payload, d)
+	url, err := buildAPIURL(config.APIURL, CHART_API_PATH)
+	if err != nil {
+		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
+	}
+
+	return resourceCreate(url, config.AuthToken, payload, d)
 }
 
 func heatmapchartRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
-	url := fmt.Sprintf("%s/%s", CHART_API_URL, d.Id())
+	path := fmt.Sprintf("%s/%s", CHART_API_PATH, d.Id())
+	url, err := buildAPIURL(config.APIURL, path)
+	if err != nil {
+		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
+	}
 
 	return resourceRead(url, config.AuthToken, d)
 }
@@ -276,14 +274,24 @@ func heatmapchartUpdate(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return fmt.Errorf("Failed creating json payload: %s", err.Error())
 	}
-	url := fmt.Sprintf("%s/%s", CHART_API_URL, d.Id())
+
+	path := fmt.Sprintf("%s/%s", CHART_API_PATH, d.Id())
+	url, err := buildAPIURL(config.APIURL, path)
+	if err != nil {
+		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
+	}
 
 	return resourceUpdate(url, config.AuthToken, payload, d)
 }
 
 func heatmapchartDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
-	url := fmt.Sprintf("%s/%s", CHART_API_URL, d.Id())
+	path := fmt.Sprintf("%s/%s", CHART_API_PATH, d.Id())
+	url, err := buildAPIURL(config.APIURL, path)
+	if err != nil {
+		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
+	}
+
 	return resourceDelete(url, config.AuthToken, d)
 }
 

--- a/signalfx/heatmap_chart.go
+++ b/signalfx/heatmap_chart.go
@@ -23,6 +23,11 @@ func heatmapChartResource() *schema.Resource {
 				Computed:    true,
 				Description: "Latest timestamp the resource was updated",
 			},
+			"url": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "URL of the chart",
+			},
 			"name": &schema.Schema{
 				Type:        schema.TypeString,
 				Required:    true,

--- a/signalfx/heatmap_chart.go
+++ b/signalfx/heatmap_chart.go
@@ -249,7 +249,7 @@ func heatmapchartCreate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Failed creating json payload: %s", err.Error())
 	}
 
-	url, err := buildAPIURL(config.APIURL, CHART_API_PATH)
+	url, err := buildURL(config.APIURL, CHART_API_PATH)
 	if err != nil {
 		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
 	}
@@ -260,7 +260,7 @@ func heatmapchartCreate(d *schema.ResourceData, meta interface{}) error {
 func heatmapchartRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 	path := fmt.Sprintf("%s/%s", CHART_API_PATH, d.Id())
-	url, err := buildAPIURL(config.APIURL, path)
+	url, err := buildURL(config.APIURL, path)
 	if err != nil {
 		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
 	}
@@ -276,7 +276,7 @@ func heatmapchartUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	path := fmt.Sprintf("%s/%s", CHART_API_PATH, d.Id())
-	url, err := buildAPIURL(config.APIURL, path)
+	url, err := buildURL(config.APIURL, path)
 	if err != nil {
 		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
 	}
@@ -287,7 +287,7 @@ func heatmapchartUpdate(d *schema.ResourceData, meta interface{}) error {
 func heatmapchartDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 	path := fmt.Sprintf("%s/%s", CHART_API_PATH, d.Id())
-	url, err := buildAPIURL(config.APIURL, path)
+	url, err := buildURL(config.APIURL, path)
 	if err != nil {
 		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
 	}

--- a/signalfx/heatmap_chart.go
+++ b/signalfx/heatmap_chart.go
@@ -259,7 +259,14 @@ func heatmapchartCreate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
 	}
 
-	return resourceCreate(url, config.AuthToken, payload, d)
+	err = resourceCreate(url, config.AuthToken, payload, d)
+	// Since things worked, set the URL and move on
+	appURL, err := buildAppURL(config.CustomAppURL, CHART_APP_PATH+d.Id())
+	if err != nil {
+		return err
+	}
+	d.Set("url", appURL)
+	return nil
 }
 
 func heatmapchartRead(d *schema.ResourceData, meta interface{}) error {

--- a/signalfx/integration.go
+++ b/signalfx/integration.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	INTEGRATION_API_URL = "https://api.signalfx.com/v2/integration"
+	INTEGRATION_API_PATH = "/v2/integration"
 )
 
 func integrationResource() *schema.Resource {
@@ -101,14 +101,21 @@ func integrationCreate(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return fmt.Errorf("Failed creating json payload: %s", err.Error())
 	}
-	url := fmt.Sprintf("%s?skipValidation=true", INTEGRATION_API_URL)
+	url, err := buildURL(config.APIURL, INTEGRATION_API_PATH)
+	if err != nil {
+		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
+	}
 
 	return resourceCreate(url, config.AuthToken, payload, d)
 }
 
 func integrationRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
-	url := fmt.Sprintf("%s/%s", INTEGRATION_API_URL, d.Id())
+	path := fmt.Sprintf("%s/%s", INTEGRATION_API_PATH, d.Id())
+	url, err := buildURL(config.APIURL, path)
+	if err != nil {
+		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
+	}
 
 	return resourceRead(url, config.AuthToken, d)
 }
@@ -119,13 +126,22 @@ func integrationUpdate(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return fmt.Errorf("Failed creating json payload: %s", err.Error())
 	}
-	url := fmt.Sprintf("%s/%s", INTEGRATION_API_URL, d.Id())
+	path := fmt.Sprintf("%s/%s", INTEGRATION_API_PATH, d.Id())
+	url, err := buildURL(config.APIURL, path)
+	if err != nil {
+		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
+	}
 
 	return resourceUpdate(url, config.AuthToken, payload, d)
 }
 
 func integrationDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
-	url := fmt.Sprintf("%s/%s", INTEGRATION_API_URL, d.Id())
+	path := fmt.Sprintf("%s/%s", INTEGRATION_API_PATH, d.Id())
+	url, err := buildURL(config.APIURL, path)
+	if err != nil {
+		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
+	}
+
 	return resourceDelete(url, config.AuthToken, d)
 }

--- a/signalfx/list_chart.go
+++ b/signalfx/list_chart.go
@@ -197,7 +197,7 @@ func listchartCreate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Failed creating json payload: %s", err.Error())
 	}
 
-	url, err := buildAPIURL(config.APIURL, CHART_API_PATH)
+	url, err := buildURL(config.APIURL, CHART_API_PATH)
 	if err != nil {
 		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
 	}
@@ -209,7 +209,7 @@ func listchartRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 
 	path := fmt.Sprintf("%s/%s", CHART_API_PATH, d.Id())
-	url, err := buildAPIURL(config.APIURL, path)
+	url, err := buildURL(config.APIURL, path)
 	if err != nil {
 		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
 	}
@@ -225,7 +225,7 @@ func listchartUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	path := fmt.Sprintf("%s/%s", CHART_API_PATH, d.Id())
-	url, err := buildAPIURL(config.APIURL, path)
+	url, err := buildURL(config.APIURL, path)
 	if err != nil {
 		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
 	}
@@ -236,7 +236,7 @@ func listchartUpdate(d *schema.ResourceData, meta interface{}) error {
 func listchartDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 	path := fmt.Sprintf("%s/%s", CHART_API_PATH, d.Id())
-	url, err := buildAPIURL(config.APIURL, path)
+	url, err := buildURL(config.APIURL, path)
 	if err != nil {
 		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
 	}

--- a/signalfx/list_chart.go
+++ b/signalfx/list_chart.go
@@ -21,17 +21,6 @@ func listChartResource() *schema.Resource {
 				Computed:    true,
 				Description: "Latest timestamp the resource was updated",
 			},
-			"resource_url": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				Default:     CHART_URL,
-				Description: "API URL of the chart",
-			},
-			"url": &schema.Schema{
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "URL of the chart",
-			},
 			"name": &schema.Schema{
 				Type:        schema.TypeString,
 				Required:    true,
@@ -208,12 +197,22 @@ func listchartCreate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Failed creating json payload: %s", err.Error())
 	}
 
-	return resourceCreate(CHART_API_URL, config.AuthToken, payload, d)
+	url, err := buildAPIURL(config.APIURL, CHART_API_PATH)
+	if err != nil {
+		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
+	}
+
+	return resourceCreate(url, config.AuthToken, payload, d)
 }
 
 func listchartRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
-	url := fmt.Sprintf("%s/%s", CHART_API_URL, d.Id())
+
+	path := fmt.Sprintf("%s/%s", CHART_API_PATH, d.Id())
+	url, err := buildAPIURL(config.APIURL, path)
+	if err != nil {
+		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
+	}
 
 	return resourceRead(url, config.AuthToken, d)
 }
@@ -224,14 +223,23 @@ func listchartUpdate(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return fmt.Errorf("Failed creating json payload: %s", err.Error())
 	}
-	url := fmt.Sprintf("%s/%s", CHART_API_URL, d.Id())
+
+	path := fmt.Sprintf("%s/%s", CHART_API_PATH, d.Id())
+	url, err := buildAPIURL(config.APIURL, path)
+	if err != nil {
+		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
+	}
 
 	return resourceUpdate(url, config.AuthToken, payload, d)
 }
 
 func listchartDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
-	url := fmt.Sprintf("%s/%s", CHART_API_URL, d.Id())
+	path := fmt.Sprintf("%s/%s", CHART_API_PATH, d.Id())
+	url, err := buildAPIURL(config.APIURL, path)
+	if err != nil {
+		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
+	}
 
 	return resourceDelete(url, config.AuthToken, d)
 }

--- a/signalfx/list_chart.go
+++ b/signalfx/list_chart.go
@@ -21,6 +21,11 @@ func listChartResource() *schema.Resource {
 				Computed:    true,
 				Description: "Latest timestamp the resource was updated",
 			},
+			"url": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "URL of the chart",
+			},
 			"name": &schema.Schema{
 				Type:        schema.TypeString,
 				Required:    true,

--- a/signalfx/list_chart.go
+++ b/signalfx/list_chart.go
@@ -207,7 +207,14 @@ func listchartCreate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
 	}
 
-	return resourceCreate(url, config.AuthToken, payload, d)
+	err = resourceCreate(url, config.AuthToken, payload, d)
+	// Since things worked, set the URL and move on
+	appURL, err := buildAppURL(config.CustomAppURL, CHART_APP_PATH+d.Id())
+	if err != nil {
+		return err
+	}
+	d.Set("url", appURL)
+	return nil
 }
 
 func listchartRead(d *schema.ResourceData, meta interface{}) error {

--- a/signalfx/provider.go
+++ b/signalfx/provider.go
@@ -19,8 +19,8 @@ var HomeConfigSuffix = "/.signalfx.conf"
 var HomeConfigPath = ""
 
 type signalfxConfig struct {
-	AuthToken       string `json:"auth_token"`
-	CustomURLPrefix string `json:"custom_url_prefix"`
+	AuthToken string `json:"auth_token"`
+	APIURL    string `json:"api_url"`
 }
 
 func Provider() terraform.ResourceProvider {
@@ -32,11 +32,11 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: schema.EnvDefaultFunc("SFX_AUTH_TOKEN", ""),
 				Description: "SignalFx auth token",
 			},
-			"custom_url_prefix": &schema.Schema{
+			"api_url": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
-				Default:     "app",
-				Description: "Custom prefix for your SignalFx org, often used with SSO",
+				Default:     "https://api.signalfx.com",
+				Description: "API URL for your SignalFx org, may include a realm",
 			},
 		},
 		ResourcesMap: map[string]*schema.Resource{

--- a/signalfx/provider.go
+++ b/signalfx/provider.go
@@ -19,8 +19,9 @@ var HomeConfigSuffix = "/.signalfx.conf"
 var HomeConfigPath = ""
 
 type signalfxConfig struct {
-	AuthToken string `json:"auth_token"`
-	APIURL    string `json:"api_url"`
+	AuthToken    string `json:"auth_token"`
+	APIURL       string `json:"api_url"`
+	CustomDomain string `json:"custom_domain"`
 }
 
 func Provider() terraform.ResourceProvider {
@@ -37,6 +38,12 @@ func Provider() terraform.ResourceProvider {
 				Optional:    true,
 				Default:     "https://api.signalfx.com",
 				Description: "API URL for your SignalFx org, may include a realm",
+			},
+			"custom_domain": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "https://app.signalfx.com",
+				Description: "Application URL for your SignalFx org, often customzied for organizations using SSO",
 			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
@@ -97,6 +104,9 @@ func signalfxConfigure(data *schema.ResourceData) (interface{}, error) {
 	}
 	if url, ok := data.GetOk("api_url"); ok {
 		config.APIURL = url.(string)
+	}
+	if custom_domain, ok := data.GetOk("custom_domain"); ok {
+		config.CustomDomain = custom_domain.(string)
 	}
 	return &config, nil
 }

--- a/signalfx/provider.go
+++ b/signalfx/provider.go
@@ -21,7 +21,7 @@ var HomeConfigPath = ""
 type signalfxConfig struct {
 	AuthToken    string `json:"auth_token"`
 	APIURL       string `json:"api_url"`
-	CustomDomain string `json:"custom_domain"`
+	CustomAppURL string `json:"custom_app_url"`
 }
 
 func Provider() terraform.ResourceProvider {
@@ -39,7 +39,7 @@ func Provider() terraform.ResourceProvider {
 				Default:     "https://api.signalfx.com",
 				Description: "API URL for your SignalFx org, may include a realm",
 			},
-			"custom_domain": &schema.Schema{
+			"custom_app_url": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
 				Default:     "https://app.signalfx.com",
@@ -105,8 +105,8 @@ func signalfxConfigure(data *schema.ResourceData) (interface{}, error) {
 	if url, ok := data.GetOk("api_url"); ok {
 		config.APIURL = url.(string)
 	}
-	if custom_domain, ok := data.GetOk("custom_domain"); ok {
-		config.CustomDomain = custom_domain.(string)
+	if custom_app_url, ok := data.GetOk("custom_app_url"); ok {
+		config.CustomAppURL = custom_app_url.(string)
 	}
 	return &config, nil
 }

--- a/signalfx/provider.go
+++ b/signalfx/provider.go
@@ -19,7 +19,8 @@ var HomeConfigSuffix = "/.signalfx.conf"
 var HomeConfigPath = ""
 
 type signalfxConfig struct {
-	AuthToken string `json:"auth_token"`
+	AuthToken       string `json:"auth_token"`
+	CustomURLPrefix string `json:"custom_url_prefix"`
 }
 
 func Provider() terraform.ResourceProvider {
@@ -30,6 +31,12 @@ func Provider() terraform.ResourceProvider {
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("SFX_AUTH_TOKEN", ""),
 				Description: "SignalFx auth token",
+			},
+			"custom_url_prefix": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "app",
+				Description: "Custom prefix for your SignalFx org, often used with SSO",
 			},
 		},
 		ResourcesMap: map[string]*schema.Resource{

--- a/signalfx/provider.go
+++ b/signalfx/provider.go
@@ -95,7 +95,9 @@ func signalfxConfigure(data *schema.ResourceData) (interface{}, error) {
 	if config.AuthToken == "" {
 		return &config, fmt.Errorf("auth_token: required field is not set")
 	}
-
+	if url, ok := data.GetOk("api_url"); ok {
+		config.APIURL = url.(string)
+	}
 	return &config, nil
 }
 

--- a/signalfx/single_value_chart.go
+++ b/signalfx/single_value_chart.go
@@ -243,7 +243,14 @@ func singlevaluechartCreate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
 	}
 
-	return resourceCreate(url, config.AuthToken, payload, d)
+	err = resourceCreate(url, config.AuthToken, payload, d)
+	// Since things worked, set the URL and move on
+	appURL, err := buildAppURL(config.CustomAppURL, CHART_APP_PATH+d.Id())
+	if err != nil {
+		return err
+	}
+	d.Set("url", appURL)
+	return nil
 }
 
 func singlevaluechartRead(d *schema.ResourceData, meta interface{}) error {

--- a/signalfx/single_value_chart.go
+++ b/signalfx/single_value_chart.go
@@ -233,7 +233,7 @@ func singlevaluechartCreate(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return fmt.Errorf("Failed creating json payload: %s", err.Error())
 	}
-	url, err := buildAPIURL(config.APIURL, CHART_API_PATH)
+	url, err := buildURL(config.APIURL, CHART_API_PATH)
 	if err != nil {
 		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
 	}
@@ -244,7 +244,7 @@ func singlevaluechartCreate(d *schema.ResourceData, meta interface{}) error {
 func singlevaluechartRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 	path := fmt.Sprintf("%s/%s", CHART_API_PATH, d.Id())
-	url, err := buildAPIURL(config.APIURL, path)
+	url, err := buildURL(config.APIURL, path)
 	if err != nil {
 		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
 	}
@@ -259,7 +259,7 @@ func singlevaluechartUpdate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Failed creating json payload: %s", err.Error())
 	}
 	path := fmt.Sprintf("%s/%s", CHART_API_PATH, d.Id())
-	url, err := buildAPIURL(config.APIURL, path)
+	url, err := buildURL(config.APIURL, path)
 	if err != nil {
 		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
 	}
@@ -270,7 +270,7 @@ func singlevaluechartUpdate(d *schema.ResourceData, meta interface{}) error {
 func singlevaluechartDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 	path := fmt.Sprintf("%s/%s", CHART_API_PATH, d.Id())
-	url, err := buildAPIURL(config.APIURL, path)
+	url, err := buildURL(config.APIURL, path)
 	if err != nil {
 		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
 	}

--- a/signalfx/single_value_chart.go
+++ b/signalfx/single_value_chart.go
@@ -22,17 +22,6 @@ func singleValueChartResource() *schema.Resource {
 				Computed:    true,
 				Description: "Latest timestamp the resource was updated",
 			},
-			"resource_url": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				Default:     CHART_URL,
-				Description: "API URL of the chart",
-			},
-			"url": &schema.Schema{
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "URL of the chart",
-			},
 			"name": &schema.Schema{
 				Type:        schema.TypeString,
 				Required:    true,
@@ -244,13 +233,21 @@ func singlevaluechartCreate(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return fmt.Errorf("Failed creating json payload: %s", err.Error())
 	}
+	url, err := buildAPIURL(config.APIURL, CHART_API_PATH)
+	if err != nil {
+		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
+	}
 
-	return resourceCreate(CHART_API_URL, config.AuthToken, payload, d)
+	return resourceCreate(url, config.AuthToken, payload, d)
 }
 
 func singlevaluechartRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
-	url := fmt.Sprintf("%s/%s", CHART_API_URL, d.Id())
+	path := fmt.Sprintf("%s/%s", CHART_API_PATH, d.Id())
+	url, err := buildAPIURL(config.APIURL, path)
+	if err != nil {
+		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
+	}
 
 	return resourceRead(url, config.AuthToken, d)
 }
@@ -261,13 +258,22 @@ func singlevaluechartUpdate(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return fmt.Errorf("Failed creating json payload: %s", err.Error())
 	}
-	url := fmt.Sprintf("%s/%s", CHART_API_URL, d.Id())
+	path := fmt.Sprintf("%s/%s", CHART_API_PATH, d.Id())
+	url, err := buildAPIURL(config.APIURL, path)
+	if err != nil {
+		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
+	}
 
 	return resourceUpdate(url, config.AuthToken, payload, d)
 }
 
 func singlevaluechartDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
-	url := fmt.Sprintf("%s/%s", CHART_API_URL, d.Id())
+	path := fmt.Sprintf("%s/%s", CHART_API_PATH, d.Id())
+	url, err := buildAPIURL(config.APIURL, path)
+	if err != nil {
+		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
+	}
+
 	return resourceDelete(url, config.AuthToken, d)
 }

--- a/signalfx/single_value_chart.go
+++ b/signalfx/single_value_chart.go
@@ -22,6 +22,11 @@ func singleValueChartResource() *schema.Resource {
 				Computed:    true,
 				Description: "Latest timestamp the resource was updated",
 			},
+			"url": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "URL of the chart",
+			},
 			"name": &schema.Schema{
 				Type:        schema.TypeString,
 				Required:    true,

--- a/signalfx/text_chart.go
+++ b/signalfx/text_chart.go
@@ -21,17 +21,6 @@ func textChartResource() *schema.Resource {
 				Computed:    true,
 				Description: "Latest timestamp the resource was updated",
 			},
-			"resource_url": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				Default:     CHART_URL,
-				Description: "API URL of the chart",
-			},
-			"url": &schema.Schema{
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "URL of the chart",
-			},
 			"name": &schema.Schema{
 				Type:        schema.TypeString,
 				Required:    true,
@@ -90,12 +79,21 @@ func textchartCreate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Failed creating json payload: %s", err.Error())
 	}
 
-	return resourceCreate(CHART_API_URL, config.AuthToken, payload, d)
+	url, err := buildAPIURL(config.APIURL, CHART_API_PATH)
+	if err != nil {
+		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
+	}
+
+	return resourceCreate(url, config.AuthToken, payload, d)
 }
 
 func textchartRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
-	url := fmt.Sprintf("%s/%s", CHART_API_URL, d.Id())
+	path := fmt.Sprintf("%s/%s", CHART_API_PATH, d.Id())
+	url, err := buildAPIURL(config.APIURL, path)
+	if err != nil {
+		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
+	}
 
 	return resourceRead(url, config.AuthToken, d)
 }
@@ -106,13 +104,22 @@ func textchartUpdate(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return fmt.Errorf("Failed creating json payload: %s", err.Error())
 	}
-	url := fmt.Sprintf("%s/%s", CHART_API_URL, d.Id())
+	path := fmt.Sprintf("%s/%s", CHART_API_PATH, d.Id())
+	url, err := buildAPIURL(config.APIURL, path)
+	if err != nil {
+		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
+	}
 
 	return resourceUpdate(url, config.AuthToken, payload, d)
 }
 
 func textchartDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
-	url := fmt.Sprintf("%s/%s", CHART_API_URL, d.Id())
+	path := fmt.Sprintf("%s/%s", CHART_API_PATH, d.Id())
+	url, err := buildAPIURL(config.APIURL, path)
+	if err != nil {
+		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
+	}
+
 	return resourceDelete(url, config.AuthToken, d)
 }

--- a/signalfx/text_chart.go
+++ b/signalfx/text_chart.go
@@ -79,7 +79,7 @@ func textchartCreate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Failed creating json payload: %s", err.Error())
 	}
 
-	url, err := buildAPIURL(config.APIURL, CHART_API_PATH)
+	url, err := buildURL(config.APIURL, CHART_API_PATH)
 	if err != nil {
 		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
 	}
@@ -90,7 +90,7 @@ func textchartCreate(d *schema.ResourceData, meta interface{}) error {
 func textchartRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 	path := fmt.Sprintf("%s/%s", CHART_API_PATH, d.Id())
-	url, err := buildAPIURL(config.APIURL, path)
+	url, err := buildURL(config.APIURL, path)
 	if err != nil {
 		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
 	}
@@ -105,7 +105,7 @@ func textchartUpdate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Failed creating json payload: %s", err.Error())
 	}
 	path := fmt.Sprintf("%s/%s", CHART_API_PATH, d.Id())
-	url, err := buildAPIURL(config.APIURL, path)
+	url, err := buildURL(config.APIURL, path)
 	if err != nil {
 		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
 	}
@@ -116,7 +116,7 @@ func textchartUpdate(d *schema.ResourceData, meta interface{}) error {
 func textchartDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 	path := fmt.Sprintf("%s/%s", CHART_API_PATH, d.Id())
-	url, err := buildAPIURL(config.APIURL, path)
+	url, err := buildURL(config.APIURL, path)
 	if err != nil {
 		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
 	}

--- a/signalfx/text_chart.go
+++ b/signalfx/text_chart.go
@@ -89,7 +89,14 @@ func textchartCreate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
 	}
 
-	return resourceCreate(url, config.AuthToken, payload, d)
+	err = resourceCreate(url, config.AuthToken, payload, d)
+	// Since things worked, set the URL and move on
+	appURL, err := buildAppURL(config.CustomAppURL, CHART_APP_PATH+d.Id())
+	if err != nil {
+		return err
+	}
+	d.Set("url", appURL)
+	return nil
 }
 
 func textchartRead(d *schema.ResourceData, meta interface{}) error {

--- a/signalfx/text_chart.go
+++ b/signalfx/text_chart.go
@@ -21,6 +21,11 @@ func textChartResource() *schema.Resource {
 				Computed:    true,
 				Description: "Latest timestamp the resource was updated",
 			},
+			"url": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "URL of the chart",
+			},
 			"name": &schema.Schema{
 				Type:        schema.TypeString,
 				Required:    true,

--- a/signalfx/time_chart.go
+++ b/signalfx/time_chart.go
@@ -657,7 +657,7 @@ func timechartCreate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Failed creating json payload: %s", err.Error())
 	}
 
-	url, err := buildAPIURL(config.APIURL, CHART_API_PATH)
+	url, err := buildURL(config.APIURL, CHART_API_PATH)
 	if err != nil {
 		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
 	}
@@ -668,7 +668,7 @@ func timechartCreate(d *schema.ResourceData, meta interface{}) error {
 func timechartRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 	path := fmt.Sprintf("%s/%s", CHART_API_PATH, d.Id())
-	url, err := buildAPIURL(config.APIURL, path)
+	url, err := buildURL(config.APIURL, path)
 	if err != nil {
 		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
 	}
@@ -683,7 +683,7 @@ func timechartUpdate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Failed creating json payload: %s", err.Error())
 	}
 	path := fmt.Sprintf("%s/%s", CHART_API_PATH, d.Id())
-	url, err := buildAPIURL(config.APIURL, path)
+	url, err := buildURL(config.APIURL, path)
 	if err != nil {
 		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
 	}
@@ -694,7 +694,7 @@ func timechartUpdate(d *schema.ResourceData, meta interface{}) error {
 func timechartDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 	path := fmt.Sprintf("%s/%s", CHART_API_PATH, d.Id())
-	url, err := buildAPIURL(config.APIURL, path)
+	url, err := buildURL(config.APIURL, path)
 	if err != nil {
 		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
 	}

--- a/signalfx/time_chart.go
+++ b/signalfx/time_chart.go
@@ -667,7 +667,14 @@ func timechartCreate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
 	}
 
-	return resourceCreate(url, config.AuthToken, payload, d)
+	err = resourceCreate(url, config.AuthToken, payload, d)
+	// Since things worked, set the URL and move on
+	appURL, err := buildAppURL(config.CustomAppURL, CHART_APP_PATH+d.Id())
+	if err != nil {
+		return err
+	}
+	d.Set("url", appURL)
+	return nil
 }
 
 func timechartRead(d *schema.ResourceData, meta interface{}) error {

--- a/signalfx/time_chart.go
+++ b/signalfx/time_chart.go
@@ -104,6 +104,11 @@ func timeChartResource() *schema.Resource {
 				Computed:    true,
 				Description: "Latest timestamp the resource was updated",
 			},
+			"url": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "URL of the chart",
+			},
 			"name": &schema.Schema{
 				Type:        schema.TypeString,
 				Required:    true,

--- a/signalfx/time_chart.go
+++ b/signalfx/time_chart.go
@@ -104,17 +104,6 @@ func timeChartResource() *schema.Resource {
 				Computed:    true,
 				Description: "Latest timestamp the resource was updated",
 			},
-			"resource_url": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				Default:     CHART_URL,
-				Description: "API URL of the chart",
-			},
-			"url": &schema.Schema{
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "URL of the chart",
-			},
 			"name": &schema.Schema{
 				Type:        schema.TypeString,
 				Required:    true,
@@ -668,12 +657,21 @@ func timechartCreate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Failed creating json payload: %s", err.Error())
 	}
 
-	return resourceCreate(CHART_API_URL, config.AuthToken, payload, d)
+	url, err := buildAPIURL(config.APIURL, CHART_API_PATH)
+	if err != nil {
+		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
+	}
+
+	return resourceCreate(url, config.AuthToken, payload, d)
 }
 
 func timechartRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
-	url := fmt.Sprintf("%s/%s", CHART_API_URL, d.Id())
+	path := fmt.Sprintf("%s/%s", CHART_API_PATH, d.Id())
+	url, err := buildAPIURL(config.APIURL, path)
+	if err != nil {
+		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
+	}
 
 	return resourceRead(url, config.AuthToken, d)
 }
@@ -684,14 +682,23 @@ func timechartUpdate(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return fmt.Errorf("Failed creating json payload: %s", err.Error())
 	}
-	url := fmt.Sprintf("%s/%s", CHART_API_URL, d.Id())
+	path := fmt.Sprintf("%s/%s", CHART_API_PATH, d.Id())
+	url, err := buildAPIURL(config.APIURL, path)
+	if err != nil {
+		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
+	}
 
 	return resourceUpdate(url, config.AuthToken, payload, d)
 }
 
 func timechartDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
-	url := fmt.Sprintf("%s/%s", CHART_API_URL, d.Id())
+	path := fmt.Sprintf("%s/%s", CHART_API_PATH, d.Id())
+	url, err := buildAPIURL(config.APIURL, path)
+	if err != nil {
+		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
+	}
+
 	return resourceDelete(url, config.AuthToken, d)
 }
 

--- a/signalfx/util.go
+++ b/signalfx/util.go
@@ -17,9 +17,8 @@ import (
 
 const (
 	// Workaround for Signalfx bug related to post processing and lastUpdatedTime
-	OFFSET        = 10000.0
-	CHART_API_URL = "https://api.signalfx.com/v2/chart"
-	CHART_URL     = "https://app.signalfx.com/#/chart/<id>"
+	OFFSET         = 10000.0
+	CHART_API_PATH = "/v2/chart"
 )
 
 type chartColor struct {

--- a/signalfx/util.go
+++ b/signalfx/util.go
@@ -173,7 +173,7 @@ func resourceRead(url string, sfxToken string, d *schema.ResourceData) error {
 			// This implies that the resouce was deleted in the Signalfx UI and therefore we need to recreate it
 			d.SetId("")
 		} else {
-			return fmt.Errorf("For the resource %s SignalFx returned status %d: \n%s", d.Get("name"), status_code, resp_body)
+			return fmt.Errorf("For the resource '%s' SignalFx returned status %d: \n%s", d.Get("name"), status_code, resp_body)
 		}
 	}
 
@@ -215,7 +215,7 @@ func resourceUpdate(url string, sfxToken string, payload []byte, d *schema.Resou
 		d.Set("synced", true)
 		d.Set("last_updated", mapped_resp["lastUpdated"].(float64))
 	} else {
-		return fmt.Errorf("For the resource %s SignalFx returned status %d: \n%s", d.Get("name"), status_code, resp_body)
+		return fmt.Errorf("For the resource '%s' SignalFx returned status %d: \n%s", d.Get("name"), status_code, resp_body)
 	}
 	return nil
 }

--- a/signalfx/util.go
+++ b/signalfx/util.go
@@ -19,6 +19,7 @@ const (
 	// Workaround for Signalfx bug related to post processing and lastUpdatedTime
 	OFFSET         = 10000.0
 	CHART_API_PATH = "/v2/chart"
+	CHART_APP_PATH = "/chart/"
 )
 
 type chartColor struct {

--- a/signalfx/util.go
+++ b/signalfx/util.go
@@ -60,6 +60,17 @@ func buildURL(apiURL string, path string) (string, error) {
 	return u.String(), nil
 }
 
+func buildAppURL(appURL string, fragment string) (string, error) {
+	// Include a trailing slash, as without this Go doesn't add one for the fragment and that seems to be a required part of the url
+	u, err := url.Parse(appURL + "/")
+	if err != nil {
+		return "", err
+	}
+	// The URL is actually a fragment, so use that instead of Path
+	u.Fragment = fragment
+	return u.String(), nil
+}
+
 /*
   Utility function that wraps http calls to SignalFx
 */

--- a/signalfx/util.go
+++ b/signalfx/util.go
@@ -50,7 +50,7 @@ var ChartColorsSlice = []chartColor{
 	{"lime_green", "#6bd37e"},
 }
 
-func buildAPIURL(apiURL string, path string) (string, error) {
+func buildURL(apiURL string, path string) (string, error) {
 	u, err := url.Parse(apiURL)
 	if err != nil {
 		return "", err

--- a/signalfx/util_test.go
+++ b/signalfx/util_test.go
@@ -98,8 +98,8 @@ func TestValidateSortByNoDirection(t *testing.T) {
 	assert.Equal(t, 1, len(errors))
 }
 
-func TestBuildAPIURL(t *testing.T) {
-	u, error := buildAPIURL("https://www.example.com", "/v2/chart")
+func TestBuildURL(t *testing.T) {
+	u, error := buildURL("https://www.example.com", "/v2/chart")
 	assert.NoError(t, error)
 	assert.Equal(t, "https://www.example.com/v2/chart", u)
 }

--- a/signalfx/util_test.go
+++ b/signalfx/util_test.go
@@ -103,3 +103,9 @@ func TestBuildURL(t *testing.T) {
 	assert.NoError(t, error)
 	assert.Equal(t, "https://www.example.com/v2/chart", u)
 }
+
+func TestBuildAppURL(t *testing.T) {
+	u, error := buildAppURL("https://www.example.com", "/chart/abc123")
+	assert.NoError(t, error)
+	assert.Equal(t, "https://www.example.com/#/chart/abc123", u)
+}

--- a/signalfx/util_test.go
+++ b/signalfx/util_test.go
@@ -97,3 +97,9 @@ func TestValidateSortByNoDirection(t *testing.T) {
 	_, errors := validateSortBy("foo", "sort_by")
 	assert.Equal(t, 1, len(errors))
 }
+
+func TestBuildAPIURL(t *testing.T) {
+	u, error := buildAPIURL("https://www.example.com", "/v2/chart")
+	assert.NoError(t, error)
+	assert.Equal(t, "https://www.example.com/v2/chart", u)
+}


### PR DESCRIPTION
# Summary

Adds a configurable `api_url` configuration option for the provider, which allows the user to change the hostname to which the API requests will be sent.  This configuration option is then used in the "client" methods to construct an appropriate URL for the API call.

Also adds a `custom_app_url` option which allows overriding the URLs for the resources.

# Motivation

This is necessary for "realm" support within SignalFx, where a user's assets are in a non-default place.

# Notes

This also removes the `resource_url` attribute from the schemas of objects. It's unclear to me what purpose these attributes served aside from providing the user with a link to the in-app dashboard for browsing. Unfortunately in organizations with custom domains, these URL is incorrect. Therefore, I removed it. This fixes #8.

The existing `url` parameter has been modified to use the `custom_app_url` and now outputs a correct value.
