### PR TITLE
Prevent dangling dashboards on group create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## Fixed
 
-* Creating a Dashboard Group no longer implicitly creates an empty dashboard of the same name. Note: This will *not* remove any dashboards previously created that way, nor will it prevent you from creating a dashboard group with nothing in it. That's on you! Thanks to [MovieStoreGuy](https://github.com/MovieStoreGuy) for flagging this.
+* Creating a Dashboard Group no longer implicitly creates an empty dashboard of the same name as a member of the group. Note: This will *not* remove any dashboards previously created that way, nor will it prevent you from creating a dashboard group with nothing in it. That's on you! Thanks to [MovieStoreGuy](https://github.com/MovieStoreGuy) for flagging this.
 
 ## Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## Fixed
 
+* Creating a Dashboard Group no longer implicitly creates an empty dashboard of the same name. Note: This will *not* remove any dashboards previously created that way, nor will it prevent you from creating a dashboard group with nothing in it. That's on you! Thanks to [MovieStoreGuy](https://github.com/MovieStoreGuy) for flagging this.
+
 ## Removed
 
 # 3.1.0, 2019-05-21

--- a/signalfx/dashboard.go
+++ b/signalfx/dashboard.go
@@ -652,7 +652,7 @@ func dashboardCreate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Failed creating json payload: %s", err.Error())
 	}
 	log.Printf("[SignalFx] Dashboard Create Payload: %s", string(payload))
-	url, err := buildURL(config.APIURL, DASHBOARD_API_PATH)
+	url, err := buildURL(config.APIURL, DASHBOARD_API_PATH, map[string]string{})
 	if err != nil {
 		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
 	}
@@ -672,7 +672,7 @@ func dashboardCreate(d *schema.ResourceData, meta interface{}) error {
 func dashboardRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 	path := fmt.Sprintf("%s/%s", DASHBOARD_API_PATH, d.Id())
-	url, err := buildURL(config.APIURL, path)
+	url, err := buildURL(config.APIURL, path, map[string]string{})
 	if err != nil {
 		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
 	}
@@ -688,7 +688,7 @@ func dashboardUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	path := fmt.Sprintf("%s/%s", DASHBOARD_API_PATH, d.Id())
-	url, err := buildURL(config.APIURL, path)
+	url, err := buildURL(config.APIURL, path, map[string]string{})
 	if err != nil {
 		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
 	}
@@ -701,7 +701,7 @@ func dashboardDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 
 	path := fmt.Sprintf("%s/%s", DASHBOARD_API_PATH, d.Id())
-	url, err := buildURL(config.APIURL, path)
+	url, err := buildURL(config.APIURL, path, map[string]string{})
 	if err != nil {
 		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
 	}

--- a/signalfx/dashboard_group.go
+++ b/signalfx/dashboard_group.go
@@ -73,7 +73,7 @@ func dashboardgroupCreate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Failed creating json payload: %s", err.Error())
 	}
 
-	url, err := buildURL(config.APIURL, DASHBOARD_GROUP_API_PATH)
+	url, err := buildURL(config.APIURL, DASHBOARD_GROUP_API_PATH, map[string]string{"empty": "true"})
 	if err != nil {
 		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
 	}
@@ -84,7 +84,7 @@ func dashboardgroupCreate(d *schema.ResourceData, meta interface{}) error {
 func dashboardgroupRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 	path := fmt.Sprintf("%s/%s", DASHBOARD_GROUP_API_PATH, d.Id())
-	url, err := buildURL(config.APIURL, path)
+	url, err := buildURL(config.APIURL, path, map[string]string{})
 	if err != nil {
 		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
 	}
@@ -99,7 +99,7 @@ func dashboardgroupUpdate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Failed creating json payload: %s", err.Error())
 	}
 	path := fmt.Sprintf("%s/%s", DASHBOARD_GROUP_API_PATH, d.Id())
-	url, err := buildURL(config.APIURL, path)
+	url, err := buildURL(config.APIURL, path, map[string]string{})
 	if err != nil {
 		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
 	}
@@ -110,7 +110,7 @@ func dashboardgroupUpdate(d *schema.ResourceData, meta interface{}) error {
 func dashboardgroupDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 	path := fmt.Sprintf("%s/%s", DASHBOARD_GROUP_API_PATH, d.Id())
-	url, err := buildURL(config.APIURL, path)
+	url, err := buildURL(config.APIURL, path, map[string]string{})
 	if err != nil {
 		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
 	}

--- a/signalfx/detector.go
+++ b/signalfx/detector.go
@@ -314,7 +314,7 @@ func detectorCreate(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return fmt.Errorf("Failed creating json payload: %s", err.Error())
 	}
-	url, err := buildURL(config.APIURL, DETECTOR_API_PATH)
+	url, err := buildURL(config.APIURL, DETECTOR_API_PATH, map[string]string{})
 	if err != nil {
 		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
 	}
@@ -335,7 +335,7 @@ func detectorCreate(d *schema.ResourceData, meta interface{}) error {
 func detectorRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 	path := fmt.Sprintf("%s/%s", DETECTOR_API_PATH, d.Id())
-	url, err := buildURL(config.APIURL, path)
+	url, err := buildURL(config.APIURL, path, map[string]string{})
 	if err != nil {
 		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
 	}
@@ -350,7 +350,7 @@ func detectorUpdate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Failed creating json payload: %s", err.Error())
 	}
 	path := fmt.Sprintf("%s/%s", DETECTOR_API_PATH, d.Id())
-	url, err := buildURL(config.APIURL, path)
+	url, err := buildURL(config.APIURL, path, map[string]string{})
 	if err != nil {
 		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
 	}
@@ -361,7 +361,7 @@ func detectorUpdate(d *schema.ResourceData, meta interface{}) error {
 func detectorDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 	path := fmt.Sprintf("%s/%s", DETECTOR_API_PATH, d.Id())
-	url, err := buildURL(config.APIURL, path)
+	url, err := buildURL(config.APIURL, path, map[string]string{})
 	if err != nil {
 		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
 	}

--- a/signalfx/heatmap_chart.go
+++ b/signalfx/heatmap_chart.go
@@ -254,7 +254,7 @@ func heatmapchartCreate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Failed creating json payload: %s", err.Error())
 	}
 
-	url, err := buildURL(config.APIURL, CHART_API_PATH)
+	url, err := buildURL(config.APIURL, CHART_API_PATH, map[string]string{})
 	if err != nil {
 		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
 	}
@@ -272,7 +272,7 @@ func heatmapchartCreate(d *schema.ResourceData, meta interface{}) error {
 func heatmapchartRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 	path := fmt.Sprintf("%s/%s", CHART_API_PATH, d.Id())
-	url, err := buildURL(config.APIURL, path)
+	url, err := buildURL(config.APIURL, path, map[string]string{})
 	if err != nil {
 		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
 	}
@@ -288,7 +288,7 @@ func heatmapchartUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	path := fmt.Sprintf("%s/%s", CHART_API_PATH, d.Id())
-	url, err := buildURL(config.APIURL, path)
+	url, err := buildURL(config.APIURL, path, map[string]string{})
 	if err != nil {
 		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
 	}
@@ -299,7 +299,7 @@ func heatmapchartUpdate(d *schema.ResourceData, meta interface{}) error {
 func heatmapchartDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 	path := fmt.Sprintf("%s/%s", CHART_API_PATH, d.Id())
-	url, err := buildURL(config.APIURL, path)
+	url, err := buildURL(config.APIURL, path, map[string]string{})
 	if err != nil {
 		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
 	}

--- a/signalfx/integration.go
+++ b/signalfx/integration.go
@@ -141,7 +141,7 @@ func integrationCreate(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return fmt.Errorf("Failed creating json payload: %s", err.Error())
 	}
-	url, err := buildURL(config.APIURL, INTEGRATION_API_PATH)
+	url, err := buildURL(config.APIURL, INTEGRATION_API_PATH, map[string]string{})
 	if err != nil {
 		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
 	}
@@ -152,7 +152,7 @@ func integrationCreate(d *schema.ResourceData, meta interface{}) error {
 func integrationRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 	path := fmt.Sprintf("%s/%s", INTEGRATION_API_PATH, d.Id())
-	url, err := buildURL(config.APIURL, path)
+	url, err := buildURL(config.APIURL, path, map[string]string{})
 	if err != nil {
 		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
 	}
@@ -167,7 +167,7 @@ func integrationUpdate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Failed creating json payload: %s", err.Error())
 	}
 	path := fmt.Sprintf("%s/%s", INTEGRATION_API_PATH, d.Id())
-	url, err := buildURL(config.APIURL, path)
+	url, err := buildURL(config.APIURL, path, map[string]string{})
 	if err != nil {
 		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
 	}
@@ -178,7 +178,7 @@ func integrationUpdate(d *schema.ResourceData, meta interface{}) error {
 func integrationDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 	path := fmt.Sprintf("%s/%s", INTEGRATION_API_PATH, d.Id())
-	url, err := buildURL(config.APIURL, path)
+	url, err := buildURL(config.APIURL, path, map[string]string{})
 	if err != nil {
 		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
 	}

--- a/signalfx/list_chart.go
+++ b/signalfx/list_chart.go
@@ -202,7 +202,7 @@ func listchartCreate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Failed creating json payload: %s", err.Error())
 	}
 
-	url, err := buildURL(config.APIURL, CHART_API_PATH)
+	url, err := buildURL(config.APIURL, CHART_API_PATH, map[string]string{})
 	if err != nil {
 		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
 	}
@@ -221,7 +221,7 @@ func listchartRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 
 	path := fmt.Sprintf("%s/%s", CHART_API_PATH, d.Id())
-	url, err := buildURL(config.APIURL, path)
+	url, err := buildURL(config.APIURL, path, map[string]string{})
 	if err != nil {
 		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
 	}
@@ -237,7 +237,7 @@ func listchartUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	path := fmt.Sprintf("%s/%s", CHART_API_PATH, d.Id())
-	url, err := buildURL(config.APIURL, path)
+	url, err := buildURL(config.APIURL, path, map[string]string{})
 	if err != nil {
 		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
 	}
@@ -248,7 +248,7 @@ func listchartUpdate(d *schema.ResourceData, meta interface{}) error {
 func listchartDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 	path := fmt.Sprintf("%s/%s", CHART_API_PATH, d.Id())
-	url, err := buildURL(config.APIURL, path)
+	url, err := buildURL(config.APIURL, path, map[string]string{})
 	if err != nil {
 		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
 	}

--- a/signalfx/single_value_chart.go
+++ b/signalfx/single_value_chart.go
@@ -238,7 +238,7 @@ func singlevaluechartCreate(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return fmt.Errorf("Failed creating json payload: %s", err.Error())
 	}
-	url, err := buildURL(config.APIURL, CHART_API_PATH)
+	url, err := buildURL(config.APIURL, CHART_API_PATH, map[string]string{})
 	if err != nil {
 		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
 	}
@@ -256,7 +256,7 @@ func singlevaluechartCreate(d *schema.ResourceData, meta interface{}) error {
 func singlevaluechartRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 	path := fmt.Sprintf("%s/%s", CHART_API_PATH, d.Id())
-	url, err := buildURL(config.APIURL, path)
+	url, err := buildURL(config.APIURL, path, map[string]string{})
 	if err != nil {
 		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
 	}
@@ -271,7 +271,7 @@ func singlevaluechartUpdate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Failed creating json payload: %s", err.Error())
 	}
 	path := fmt.Sprintf("%s/%s", CHART_API_PATH, d.Id())
-	url, err := buildURL(config.APIURL, path)
+	url, err := buildURL(config.APIURL, path, map[string]string{})
 	if err != nil {
 		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
 	}
@@ -282,7 +282,7 @@ func singlevaluechartUpdate(d *schema.ResourceData, meta interface{}) error {
 func singlevaluechartDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 	path := fmt.Sprintf("%s/%s", CHART_API_PATH, d.Id())
-	url, err := buildURL(config.APIURL, path)
+	url, err := buildURL(config.APIURL, path, map[string]string{})
 	if err != nil {
 		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
 	}

--- a/signalfx/text_chart.go
+++ b/signalfx/text_chart.go
@@ -84,7 +84,7 @@ func textchartCreate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Failed creating json payload: %s", err.Error())
 	}
 
-	url, err := buildURL(config.APIURL, CHART_API_PATH)
+	url, err := buildURL(config.APIURL, CHART_API_PATH, map[string]string{})
 	if err != nil {
 		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
 	}
@@ -102,7 +102,7 @@ func textchartCreate(d *schema.ResourceData, meta interface{}) error {
 func textchartRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 	path := fmt.Sprintf("%s/%s", CHART_API_PATH, d.Id())
-	url, err := buildURL(config.APIURL, path)
+	url, err := buildURL(config.APIURL, path, map[string]string{})
 	if err != nil {
 		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
 	}
@@ -117,7 +117,7 @@ func textchartUpdate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Failed creating json payload: %s", err.Error())
 	}
 	path := fmt.Sprintf("%s/%s", CHART_API_PATH, d.Id())
-	url, err := buildURL(config.APIURL, path)
+	url, err := buildURL(config.APIURL, path, map[string]string{})
 	if err != nil {
 		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
 	}
@@ -128,7 +128,7 @@ func textchartUpdate(d *schema.ResourceData, meta interface{}) error {
 func textchartDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 	path := fmt.Sprintf("%s/%s", CHART_API_PATH, d.Id())
-	url, err := buildURL(config.APIURL, path)
+	url, err := buildURL(config.APIURL, path, map[string]string{})
 	if err != nil {
 		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
 	}

--- a/signalfx/time_chart.go
+++ b/signalfx/time_chart.go
@@ -662,7 +662,7 @@ func timechartCreate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Failed creating json payload: %s", err.Error())
 	}
 
-	url, err := buildURL(config.APIURL, CHART_API_PATH)
+	url, err := buildURL(config.APIURL, CHART_API_PATH, map[string]string{})
 	if err != nil {
 		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
 	}
@@ -680,7 +680,7 @@ func timechartCreate(d *schema.ResourceData, meta interface{}) error {
 func timechartRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 	path := fmt.Sprintf("%s/%s", CHART_API_PATH, d.Id())
-	url, err := buildURL(config.APIURL, path)
+	url, err := buildURL(config.APIURL, path, map[string]string{})
 	if err != nil {
 		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
 	}
@@ -695,7 +695,7 @@ func timechartUpdate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Failed creating json payload: %s", err.Error())
 	}
 	path := fmt.Sprintf("%s/%s", CHART_API_PATH, d.Id())
-	url, err := buildURL(config.APIURL, path)
+	url, err := buildURL(config.APIURL, path, map[string]string{})
 	if err != nil {
 		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
 	}
@@ -706,7 +706,7 @@ func timechartUpdate(d *schema.ResourceData, meta interface{}) error {
 func timechartDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*signalfxConfig)
 	path := fmt.Sprintf("%s/%s", CHART_API_PATH, d.Id())
-	url, err := buildURL(config.APIURL, path)
+	url, err := buildURL(config.APIURL, path, map[string]string{})
 	if err != nil {
 		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
 	}

--- a/signalfx/util.go
+++ b/signalfx/util.go
@@ -51,13 +51,22 @@ var ChartColorsSlice = []chartColor{
 	{"lime_green", "#6bd37e"},
 }
 
-func buildURL(apiURL string, path string) (string, error) {
+func buildURL(apiURL string, path string, params map[string]string) (string, error) {
 	u, err := url.Parse(apiURL)
 	if err != nil {
 		return "", err
 	}
 
 	u.Path = path
+
+	if len(params) > 0 {
+		q := u.Query()
+		for k, v := range params {
+			q.Set(k, v)
+		}
+		u.RawQuery = q.Encode()
+	}
+
 	return u.String(), nil
 }
 

--- a/signalfx/util_test.go
+++ b/signalfx/util_test.go
@@ -99,9 +99,15 @@ func TestValidateSortByNoDirection(t *testing.T) {
 }
 
 func TestBuildURL(t *testing.T) {
-	u, error := buildURL("https://www.example.com", "/v2/chart")
+	u, error := buildURL("https://www.example.com", "/v2/chart", map[string]string{})
 	assert.NoError(t, error)
 	assert.Equal(t, "https://www.example.com/v2/chart", u)
+}
+
+func TestBuildURLWithParams(t *testing.T) {
+	u, error := buildURL("https://www.example.com", "/v2/chart", map[string]string{"foo": "bar"})
+	assert.NoError(t, error)
+	assert.Equal(t, "https://www.example.com/v2/chart?foo=bar", u)
 }
 
 func TestBuildAppURL(t *testing.T) {


### PR DESCRIPTION
# Summary

Stops the creation of an empty dashboard when we create a dashboard group.

# Motivation

See #14 which covers the reason this was happening.

