### PR TITLE
Make sure we cause an error when a chart fails to create

### DIFF
--- a/signalfx/heatmap_chart.go
+++ b/signalfx/heatmap_chart.go
@@ -260,6 +260,9 @@ func heatmapchartCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	err = resourceCreate(url, config.AuthToken, payload, d)
+	if err != nil {
+		return err
+	}
 	// Since things worked, set the URL and move on
 	appURL, err := buildAppURL(config.CustomAppURL, CHART_APP_PATH+d.Id())
 	if err != nil {

--- a/signalfx/list_chart.go
+++ b/signalfx/list_chart.go
@@ -208,6 +208,9 @@ func listchartCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	err = resourceCreate(url, config.AuthToken, payload, d)
+	if err != nil {
+		return err
+	}
 	// Since things worked, set the URL and move on
 	appURL, err := buildAppURL(config.CustomAppURL, CHART_APP_PATH+d.Id())
 	if err != nil {

--- a/signalfx/single_value_chart.go
+++ b/signalfx/single_value_chart.go
@@ -244,6 +244,9 @@ func singlevaluechartCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	err = resourceCreate(url, config.AuthToken, payload, d)
+	if err != nil {
+		return err
+	}
 	// Since things worked, set the URL and move on
 	appURL, err := buildAppURL(config.CustomAppURL, CHART_APP_PATH+d.Id())
 	if err != nil {

--- a/signalfx/text_chart.go
+++ b/signalfx/text_chart.go
@@ -90,6 +90,9 @@ func textchartCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	err = resourceCreate(url, config.AuthToken, payload, d)
+	if err != nil {
+		return err
+	}
 	// Since things worked, set the URL and move on
 	appURL, err := buildAppURL(config.CustomAppURL, CHART_APP_PATH+d.Id())
 	if err != nil {

--- a/signalfx/time_chart.go
+++ b/signalfx/time_chart.go
@@ -668,6 +668,9 @@ func timechartCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	err = resourceCreate(url, config.AuthToken, payload, d)
+	if err != nil {
+		return err
+	}
 	// Since things worked, set the URL and move on
 	appURL, err := buildAppURL(config.CustomAppURL, CHART_APP_PATH+d.Id())
 	if err != nil {


### PR DESCRIPTION
We found that sometimes charts will fail to create silently, then you would find out when the dashboard gets created Terraform complains the ID is missing. This way you can see the actual error creating the chart.