### PR TITLE
Add new form of all integrations, tests and use those methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Added docs for Slack integration.
 * Added acceptance tests for Integration and Detector.
 * [New resource](https://github.com/signalfx/terraform-provider-signalfx/pull/35) `signalfx_event_feed_chart` for [Event Feed charts](https://docs.signalfx.com/en/latest/dashboards/dashboard-add-info.html#adding-an-event-feed-chart-to-a-dashboard).
+* [New resources](https://github.com/signalfx/terraform-provider-signalfx/pull/34) `resource_pagerduty_integration` and `resource_gcp_integration` which completes the trifecta needed to get rid of `resource_integration` in the future.
 
 ## Fixed
 

--- a/docs/resources/integration.md
+++ b/docs/resources/integration.md
@@ -43,6 +43,7 @@ resource "signalfx_integration" "slack_myteam" {
     type = "Slack"
     webhook_url = "http://example.com"
 }
+```
 
 ## Argument Reference
 

--- a/signalfx/integration_gcp.go
+++ b/signalfx/integration_gcp.go
@@ -1,0 +1,118 @@
+package signalfx
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+// This resource leverages common methods for read and delete from
+// integration.go!
+
+func integrationGCPResource() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"synced": &schema.Schema{
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "Whether the resource in the provider and SignalFx are identical or not. Used internally for syncing.",
+			},
+			"last_updated": &schema.Schema{
+				Type:        schema.TypeFloat,
+				Computed:    true,
+				Description: "Latest timestamp the resource was updated",
+			},
+			"name": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Name of the integration",
+			},
+			"enabled": &schema.Schema{
+				Type:        schema.TypeBool,
+				Required:    true,
+				Description: "Whether the integration is enabled or not",
+			},
+			"poll_rate": &schema.Schema{
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Description:  "GCP poll rate",
+				ValidateFunc: validatePollRate,
+			},
+			"services": &schema.Schema{
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "GCP enabled services",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"project_service_keys": &schema.Schema{
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "GCP project service keys",
+				Sensitive:   true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"project_id": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"project_key": {
+							Type:      schema.TypeString,
+							Required:  true,
+							Sensitive: true,
+						},
+					},
+				},
+			},
+		},
+
+		Create: integrationGCPCreate,
+		Read:   integrationRead,
+		Update: integrationGCPUpdate,
+		Delete: integrationDelete,
+	}
+}
+
+func getGCPPayloadIntegration(d *schema.ResourceData) ([]byte, error) {
+	payload := map[string]interface{}{
+		"name":               d.Get("name").(string),
+		"enabled":            d.Get("enabled").(bool),
+		"type":               "GCP",
+		"pollRate":           d.Get("poll_rate").(int),
+		"services":           expandServices(d.Get("services").([]interface{})),
+		"projectServiceKeys": expandProjectServiceKeys(d.Get("project_service_keys").([]interface{})),
+	}
+	return json.Marshal(payload)
+}
+
+func integrationGCPCreate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*signalfxConfig)
+	payload, err := getGCPPayloadIntegration(d)
+	if err != nil {
+		return fmt.Errorf("Failed creating json payload: %s", err.Error())
+	}
+	url, err := buildURL(config.APIURL, INTEGRATION_API_PATH, map[string]string{})
+	if err != nil {
+		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
+	}
+
+	return resourceCreate(url, config.AuthToken, payload, d)
+}
+
+func integrationGCPUpdate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*signalfxConfig)
+	payload, err := getGCPPayloadIntegration(d)
+	if err != nil {
+		return fmt.Errorf("Failed creating json payload: %s", err.Error())
+	}
+	path := fmt.Sprintf("%s/%s", INTEGRATION_API_PATH, d.Id())
+	url, err := buildURL(config.APIURL, path, map[string]string{})
+	if err != nil {
+		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
+	}
+
+	return resourceUpdate(url, config.AuthToken, payload, d)
+}

--- a/signalfx/integration_slack.go
+++ b/signalfx/integration_slack.go
@@ -1,0 +1,89 @@
+package signalfx
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+// This resource leverages common methods for read and delete from
+// integration.go!
+
+func integrationSlackResource() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"synced": &schema.Schema{
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "Whether the resource in the provider and SignalFx are identical or not. Used internally for syncing.",
+			},
+			"last_updated": &schema.Schema{
+				Type:        schema.TypeFloat,
+				Computed:    true,
+				Description: "Latest timestamp the resource was updated",
+			},
+			"name": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Name of the integration",
+			},
+			"enabled": &schema.Schema{
+				Type:        schema.TypeBool,
+				Required:    true,
+				Description: "Whether the integration is enabled or not",
+			},
+			"webhook_url": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Slack Webhook URL for integration",
+				Sensitive:   true,
+			},
+		},
+
+		Create: integrationSlackCreate,
+		Read:   integrationRead,
+		Update: integrationSlackUpdate,
+		Delete: integrationDelete,
+	}
+}
+
+func getSlackPayloadIntegration(d *schema.ResourceData) ([]byte, error) {
+	payload := map[string]interface{}{
+		"name":       d.Get("name").(string),
+		"enabled":    d.Get("enabled").(bool),
+		"type":       "Slack",
+		"webhookUrl": d.Get("webhook_url").(string),
+	}
+	return json.Marshal(payload)
+}
+
+func integrationSlackCreate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*signalfxConfig)
+	payload, err := getSlackPayloadIntegration(d)
+	if err != nil {
+		return fmt.Errorf("Failed creating json payload: %s", err.Error())
+	}
+	url, err := buildURL(config.APIURL, INTEGRATION_API_PATH, map[string]string{})
+	if err != nil {
+		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
+	}
+
+	return resourceCreate(url, config.AuthToken, payload, d)
+}
+
+func integrationSlackUpdate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*signalfxConfig)
+	payload, err := getSlackPayloadIntegration(d)
+	if err != nil {
+		return fmt.Errorf("Failed creating json payload: %s", err.Error())
+	}
+	path := fmt.Sprintf("%s/%s", INTEGRATION_API_PATH, d.Id())
+	url, err := buildURL(config.APIURL, path, map[string]string{})
+	if err != nil {
+		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
+	}
+
+	return resourceUpdate(url, config.AuthToken, payload, d)
+}

--- a/signalfx/provider.go
+++ b/signalfx/provider.go
@@ -57,7 +57,9 @@ func Provider() terraform.ResourceProvider {
 			"signalfx_dashboard":             dashboardResource(),
 			"signalfx_dashboard_group":       dashboardGroupResource(),
 			"signalfx_integration":           integrationResource(),
+			"signalfx_gcp_integration":       integrationGCPResource(),
 			"signalfx_pagerduty_integration": integrationPagerDutyResource(),
+			"signalfx_slack_integration":     integrationSlackResource(),
 		},
 		ConfigureFunc: signalfxConfigure,
 	}

--- a/signalfx/resource_integration_gcp_test.go
+++ b/signalfx/resource_integration_gcp_test.go
@@ -1,0 +1,104 @@
+package signalfx
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/hashicorp/terraform/terraform"
+
+	sfx "github.com/signalfx/signalfx-go"
+)
+
+const newIntegrationGCPConfig = `
+resource "signalfx_gcp_integration" "gcp_myteam" {
+    name = "GCP - My Team"
+    enabled = true
+    poll_rate = 300000
+    services = ["compute"]
+    project_service_keys = [
+        {
+            project_id = "gcp_project_id_1"
+            project_key = "secret_farts"
+        },
+        {
+            project_id = "gcp_project_id_2"
+            project_key = "secret_farts_2"
+        }
+    ]
+}
+`
+
+const updatedIntegrationGCPConfig = `
+resource "signalfx_gcp_integration" "gcp_myteam" {
+    name = "GCP - My Team 2"
+    enabled = true
+    poll_rate = 300000
+    services = ["compute"]
+    project_service_keys = [
+        {
+            project_id = "gcp_project_id_1"
+            project_key = "secret_farts"
+        },
+        {
+            project_id = "gcp_project_id_2"
+            project_key = "secret_farts_2"
+        }
+    ]
+}
+`
+
+// Commented out because SignalFx validates incoming keys and ours aren't valid.
+// func TestAccCreateIntegrationGCP(t *testing.T) {
+// 	resource.Test(t, resource.TestCase{
+// 		PreCheck:     func() { testAccPreCheck(t) },
+// 		Providers:    testAccProviders,
+// 		CheckDestroy: testAccIntegrationGCPDestroy,
+// 		Steps: []resource.TestStep{
+// 			// Create It
+// 			{
+// 				Config: newIntegrationGCPConfig,
+// 				Check:  testAccCheckIntegrationGCPResourceExists,
+// 			},
+// 			// Update It
+// 			{
+// 				Config: updatedIntegrationGCPConfig,
+// 				Check:  testAccCheckIntegrationGCPResourceExists,
+// 			},
+// 		},
+// 	})
+// }
+
+func testAccCheckIntegrationGCPResourceExists(s *terraform.State) error {
+	client, _ := sfx.NewClient(os.Getenv("SFX_AUTH_TOKEN"))
+
+	for _, rs := range s.RootModule().Resources {
+		switch rs.Type {
+		case "signalfx_gcp_integration":
+			integration, err := client.GetIntegration(rs.Primary.ID)
+			if integration["id"].(string) != rs.Primary.ID || err != nil {
+				return fmt.Errorf("Error finding integration %s: %s", rs.Primary.ID, err)
+			}
+		default:
+			return fmt.Errorf("Unexpected resource of type: %s", rs.Type)
+		}
+	}
+
+	return nil
+}
+
+func testAccIntegrationGCPDestroy(s *terraform.State) error {
+	client, _ := sfx.NewClient(os.Getenv("SFX_AUTH_TOKEN"))
+	for _, rs := range s.RootModule().Resources {
+		switch rs.Type {
+		case "signalfx_gcp_integration":
+			integration, _ := client.GetIntegration(rs.Primary.ID)
+			if _, ok := integration["id"]; ok {
+				return fmt.Errorf("Found deleted integration %s", rs.Primary.ID)
+			}
+		default:
+			return fmt.Errorf("Unexpected resource of type: %s", rs.Type)
+		}
+	}
+
+	return nil
+}

--- a/signalfx/resource_integration_pagerduty_test.go
+++ b/signalfx/resource_integration_pagerduty_test.go
@@ -1,0 +1,82 @@
+package signalfx
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/hashicorp/terraform/terraform"
+
+	sfx "github.com/signalfx/signalfx-go"
+)
+
+const newIntegrationPagerDutyConfig = `
+resource "signalfx_pagerduty_integration" "pagerduty_myteam" {
+    name = "PD - My Team"
+    enabled = true
+    api_key = "1234567890"
+}
+`
+
+const updatedIntegrationPagerDutyConfig = `
+resource "signalfx_pagerduty_integration" "pagerduty_myteam" {
+    name = "PD - My Team 2"
+    enabled = true
+    api_key = "1234567890"
+}
+`
+
+// Commented out because SignalFx validates incoming keys and ours aren't valid.
+// func TestAccCreateIntegrationPagerDuty(t *testing.T) {
+// 	resource.Test(t, resource.TestCase{
+// 		PreCheck:     func() { testAccPreCheck(t) },
+// 		Providers:    testAccProviders,
+// 		CheckDestroy: testAccIntegrationPagerDutyDestroy,
+// 		Steps: []resource.TestStep{
+// 			// Create It
+// 			{
+// 				Config: newIntegrationPagerDutyConfig,
+// 				Check:  testAccCheckIntegrationPagerDutyResourceExists,
+// 			},
+// 			// Update It
+// 			{
+// 				Config: updatedIntegrationPagerDutyConfig,
+// 				Check:  testAccCheckIntegrationPagerDutyResourceExists,
+// 			},
+// 		},
+// 	})
+// }
+
+func testAccCheckIntegrationPagerDutyResourceExists(s *terraform.State) error {
+	client, _ := sfx.NewClient(os.Getenv("SFX_AUTH_TOKEN"))
+
+	for _, rs := range s.RootModule().Resources {
+		switch rs.Type {
+		case "signalfx_pagerduty_integration":
+			integration, err := client.GetIntegration(rs.Primary.ID)
+			if integration["id"].(string) != rs.Primary.ID || err != nil {
+				return fmt.Errorf("Error finding integration %s: %s", rs.Primary.ID, err)
+			}
+		default:
+			return fmt.Errorf("Unexpected resource of type: %s", rs.Type)
+		}
+	}
+
+	return nil
+}
+
+func testAccIntegrationPagerDutyDestroy(s *terraform.State) error {
+	client, _ := sfx.NewClient(os.Getenv("SFX_AUTH_TOKEN"))
+	for _, rs := range s.RootModule().Resources {
+		switch rs.Type {
+		case "signalfx_pagerduty_integration":
+			integration, _ := client.GetIntegration(rs.Primary.ID)
+			if _, ok := integration["id"]; ok {
+				return fmt.Errorf("Found deleted integration %s", rs.Primary.ID)
+			}
+		default:
+			return fmt.Errorf("Unexpected resource of type: %s", rs.Type)
+		}
+	}
+
+	return nil
+}

--- a/signalfx/resource_integration_slack_test.go
+++ b/signalfx/resource_integration_slack_test.go
@@ -1,0 +1,83 @@
+package signalfx
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+
+	sfx "github.com/signalfx/signalfx-go"
+)
+
+const newIntegrationSlackConfig = `
+resource "signalfx_slack_integration" "slack_myteam" {
+    name = "Slack - My Team"
+    enabled = true
+    webhook_url = "http://example.com"
+}
+`
+
+const updatedIntegrationSlackConfig = `
+resource "signalfx_slack_integration" "slack_myteam" {
+    name = "Slack - My Team"
+    enabled = true
+    webhook_url = "http://example.com"
+}
+`
+
+func TestAccCreateIntegrationSlack(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccIntegrationSlackDestroy,
+		Steps: []resource.TestStep{
+			// Create It
+			{
+				Config: newIntegrationSlackConfig,
+				Check:  testAccCheckIntegrationSlackResourceExists,
+			},
+			// Update It
+			{
+				Config: updatedIntegrationSlackConfig,
+				Check:  testAccCheckIntegrationSlackResourceExists,
+			},
+		},
+	})
+}
+
+func testAccCheckIntegrationSlackResourceExists(s *terraform.State) error {
+	client, _ := sfx.NewClient(os.Getenv("SFX_AUTH_TOKEN"))
+
+	for _, rs := range s.RootModule().Resources {
+		switch rs.Type {
+		case "signalfx_slack_integration":
+			integration, err := client.GetIntegration(rs.Primary.ID)
+			if integration["id"].(string) != rs.Primary.ID || err != nil {
+				return fmt.Errorf("Error finding integration %s: %s", rs.Primary.ID, err)
+			}
+		default:
+			return fmt.Errorf("Unexpected resource of type: %s", rs.Type)
+		}
+	}
+
+	return nil
+}
+
+func testAccIntegrationSlackDestroy(s *terraform.State) error {
+	client, _ := sfx.NewClient(os.Getenv("SFX_AUTH_TOKEN"))
+	for _, rs := range s.RootModule().Resources {
+		switch rs.Type {
+		case "signalfx_slack_integration":
+			integration, _ := client.GetIntegration(rs.Primary.ID)
+			if _, ok := integration["id"]; ok {
+				return fmt.Errorf("Found deleted integration %s", rs.Primary.ID)
+			}
+		default:
+			return fmt.Errorf("Unexpected resource of type: %s", rs.Type)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
# Summary

Add new-style integrations for GCP and Slack

# Motivation

In #17 I decided that the existing integration resource was not manageable long-term. The problem is that all of the schema fiddling required to represent them is going to become a minefield. Even though it differs from the [SignalFx API](https://developers.signalfx.com/integrations_reference.html#tag/Create-Integration) this is a beter experience.

# Notes
In addition to the addition of these resources, I also unified the code that reads the schema so that we didn't have to test two things.