### PR TITLE
Add resource for event feed charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Added docs for Slack integration.
 * Added acceptance tests for Integration and Detector.
-* [New resource]() `signalfx_event_feed_chart` for [Event Feed charts](https://docs.signalfx.com/en/latest/dashboards/dashboard-add-info.html#adding-an-event-feed-chart-to-a-dashboard).
+* [New resource](https://github.com/signalfx/terraform-provider-signalfx/pull/35) `signalfx_event_feed_chart` for [Event Feed charts](https://docs.signalfx.com/en/latest/dashboards/dashboard-add-info.html#adding-an-event-feed-chart-to-a-dashboard).
 
 ## Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Added docs for Slack integration.
 * Added acceptance tests for Integration and Detector.
+* [New resource]() `signalfx_event_feed_chart` for [Event Feed charts](https://docs.signalfx.com/en/latest/dashboards/dashboard-add-info.html#adding-an-event-feed-chart-to-a-dashboard).
 
 ## Fixed
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This provider was originally created and maintained by [Yelp](https://www.yelp.c
         * [Single Value Chart](https://github.com/signalfx/terraform-provider-signalfx/blob/master/docs/resources/single_value_chart.md)
         * [Heatmap Chart](https://github.com/signalfx/terraform-provider-signalfx/blob/master/docs/resources/heatmap_chart.md)
         * [Text Note](https://github.com/signalfx/terraform-provider-signalfx/blob/master/docs/resources/text_note.md)
+        * [Event Feed](https://github.com/signalfx/terraform-provider-signalfx/blob/master/docs/resources/event_feed_chart.md)
     * [Dashboard](https://github.com/signalfx/terraform-provider-signalfx/blob/master/docs/resources/dashboard.md)
     * [Dashboard Group](https://github.com/signalfx/terraform-provider-signalfx/blob/master/docs/resources/dashboard_group.md)
     * [Integration](https://github.com/signalfx/terraform-provider-signalfx/blob/master/docs/resources/integration.md)

--- a/docs/resources/event_feed_chart.md
+++ b/docs/resources/event_feed_chart.md
@@ -1,0 +1,26 @@
+# Text Note
+
+This special type of chart doesn’t display any metric data. Rather, it lets you place a text note on the dashboard.
+
+![Text Note](https://github.com/signalfx/terraform-provider-signalfx/raw/master/docs/resources/text_note.png)
+
+
+## Example Usage
+
+```terraform
+resource "signalfx_event_feed_chart" "mynote0" {
+    name = "Important Dashboard Note"
+    description = "Lorem ipsum dolor sit amet"
+    program_text = "A = events(eventType='Fart Testing').publish(label='A')"
+}
+```
+
+
+## Argument Reference
+
+The following arguments are supported in the resource block:
+
+* `name` - (Required) Name of the text note.
+* `program_text` - (Required) Signalflow program text for the chart. More info at <https://developers.signalfx.com/docs/signalflow-overview>.
+* `description` - (Optional) Description of the text note.
+* `synced` - (Optional) Whether the resource in the provider and SignalFx are identical or not. Used internally for syncing, you do not need to specify it. Whenever you see a change to this field in the plan, it means that your resource has been changed from the UI and Terraform is now going to re-sync it back to what is in your configuration.

--- a/docs/resources/event_feed_chart.md
+++ b/docs/resources/event_feed_chart.md
@@ -1,9 +1,6 @@
-# Text Note
+# Event Feed
 
-This special type of chart doesn’t display any metric data. Rather, it lets you place a text note on the dashboard.
-
-![Text Note](https://github.com/signalfx/terraform-provider-signalfx/raw/master/docs/resources/text_note.png)
-
+Displays a listing of events as a widget in a dashboard.
 
 ## Example Usage
 
@@ -12,6 +9,11 @@ resource "signalfx_event_feed_chart" "mynote0" {
     name = "Important Dashboard Note"
     description = "Lorem ipsum dolor sit amet"
     program_text = "A = events(eventType='Fart Testing').publish(label='A')"
+
+    viz_options {
+        label = "A"
+        color = "orange"
+    }
 }
 ```
 
@@ -23,4 +25,7 @@ The following arguments are supported in the resource block:
 * `name` - (Required) Name of the text note.
 * `program_text` - (Required) Signalflow program text for the chart. More info at <https://developers.signalfx.com/docs/signalflow-overview>.
 * `description` - (Optional) Description of the text note.
+* `viz_options` - (Optional) Plot-level customization options, associated with a publish statement.
+    * `label` - (Required) Label used in the publish statement that displays the plot (event data) you want to customize.
+    * `color` - (Optional) Color to use : gray, blue, azure, navy, brown, orange, yellow, iris, magenta, pink, purple, violet, lilac, emerald, green, aquamarine. ![Colors](https://github.com/signalfx/terraform-provider-signalfx/raw/master/docs/resources/colors.png)
 * `synced` - (Optional) Whether the resource in the provider and SignalFx are identical or not. Used internally for syncing, you do not need to specify it. Whenever you see a change to this field in the plan, it means that your resource has been changed from the UI and Terraform is now going to re-sync it back to what is in your configuration.

--- a/signalfx/event_feed_chart.go
+++ b/signalfx/event_feed_chart.go
@@ -1,0 +1,138 @@
+package signalfx
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func eventFeedChartResource() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"synced": &schema.Schema{
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "Whether the resource in the provider and SignalFx are identical or not. Used internally for syncing.",
+			},
+			"last_updated": &schema.Schema{
+				Type:        schema.TypeFloat,
+				Computed:    true,
+				Description: "Latest timestamp the resource was updated",
+			},
+			"url": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "URL of the chart",
+			},
+			"name": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Name of the chart",
+			},
+			"description": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Description of the chart (Optional)",
+			},
+			"program_text": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Signalflow program text for the chart. More info at \"https://developers.signalfx.com/docs/signalflow-overview\"",
+			},
+		},
+
+		Create: eventFeedChartCreate,
+		Read:   eventFeedChartRead,
+		Update: eventFeedChartUpdate,
+		Delete: eventFeedChartDelete,
+	}
+}
+
+/*
+  Use Resource object to construct json payload in order to create an event feed chart
+*/
+func getPayloadEventFeedChart(d *schema.ResourceData) ([]byte, error) {
+	payload := map[string]interface{}{
+		"name":        d.Get("name").(string),
+		"description": d.Get("description").(string),
+		"programText": d.Get("program_text").(string),
+	}
+
+	viz := getEventFeedOptions(d)
+	if len(viz) > 0 {
+		payload["options"] = viz
+	}
+
+	return json.Marshal(payload)
+}
+
+func getEventFeedOptions(d *schema.ResourceData) map[string]interface{} {
+	viz := make(map[string]interface{})
+	viz["type"] = "Event"
+
+	return viz
+}
+
+func eventFeedChartCreate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*signalfxConfig)
+	payload, err := getPayloadEventFeedChart(d)
+	if err != nil {
+		return fmt.Errorf("Failed creating json payload: %s", err.Error())
+	}
+
+	url, err := buildURL(config.APIURL, CHART_API_PATH, map[string]string{})
+	if err != nil {
+		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
+	}
+
+	err = resourceCreate(url, config.AuthToken, payload, d)
+	if err != nil {
+		return err
+	}
+	// Since things worked, set the URL and move on
+	appURL, err := buildAppURL(config.CustomAppURL, CHART_APP_PATH+d.Id())
+	if err != nil {
+		return err
+	}
+	d.Set("url", appURL)
+	return nil
+}
+
+func eventFeedChartRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*signalfxConfig)
+	path := fmt.Sprintf("%s/%s", CHART_API_PATH, d.Id())
+	url, err := buildURL(config.APIURL, path, map[string]string{})
+	if err != nil {
+		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
+	}
+
+	return resourceRead(url, config.AuthToken, d)
+}
+
+func eventFeedChartUpdate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*signalfxConfig)
+	payload, err := getPayloadEventFeedChart(d)
+	if err != nil {
+		return fmt.Errorf("Failed creating json payload: %s", err.Error())
+	}
+	path := fmt.Sprintf("%s/%s", CHART_API_PATH, d.Id())
+	url, err := buildURL(config.APIURL, path, map[string]string{})
+	if err != nil {
+		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
+	}
+
+	return resourceUpdate(url, config.AuthToken, payload, d)
+}
+
+func eventFeedChartDelete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*signalfxConfig)
+	path := fmt.Sprintf("%s/%s", CHART_API_PATH, d.Id())
+	url, err := buildURL(config.APIURL, path, map[string]string{})
+	if err != nil {
+		return fmt.Errorf("[SignalFx] Error constructing API URL: %s", err.Error())
+	}
+
+	return resourceDelete(url, config.AuthToken, d)
+}

--- a/signalfx/event_feed_chart.go
+++ b/signalfx/event_feed_chart.go
@@ -41,6 +41,26 @@ func eventFeedChartResource() *schema.Resource {
 				Required:    true,
 				Description: "Signalflow program text for the chart. More info at \"https://developers.signalfx.com/docs/signalflow-overview\"",
 			},
+			"viz_options": &schema.Schema{
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Description: "Plot-level customization options, associated with a publish statement",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"label": &schema.Schema{
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "The label used in the publish statement that displays the plot (metric time series data) you want to customize",
+						},
+						"color": &schema.Schema{
+							Type:         schema.TypeString,
+							Optional:     true,
+							Description:  "Color to use",
+							ValidateFunc: validatePerSignalColor,
+						},
+					},
+				},
+			},
 		},
 
 		Create: eventFeedChartCreate,

--- a/signalfx/provider.go
+++ b/signalfx/provider.go
@@ -49,6 +49,7 @@ func Provider() terraform.ResourceProvider {
 		ResourcesMap: map[string]*schema.Resource{
 			"signalfx_detector":              detectorResource(),
 			"signalfx_time_chart":            timeChartResource(),
+			"signalfx_event_feed_chart":      eventFeedChartResource(),
 			"signalfx_heatmap_chart":         heatmapChartResource(),
 			"signalfx_single_value_chart":    singleValueChartResource(),
 			"signalfx_list_chart":            listChartResource(),

--- a/signalfx/resource_dashboard_and_friends_test.go
+++ b/signalfx/resource_dashboard_and_friends_test.go
@@ -267,6 +267,12 @@ resource "signalfx_text_chart" "mynote0" {
     EOF
 }
 
+resource "signalfx_event_feed_chart" "myeventfeed0" {
+	name = "Interesting Events"
+	description = "Lorem ipsum dolor sit fartet"
+	program_text = "A = events(eventType='Fart Testing').publish(label='A')"
+}
+
 resource "signalfx_dashboard_group" "mydashboardgroup0" {
     name = "My team dashboard group NEW"
     description = "Cool dashboard group "
@@ -346,10 +352,10 @@ func testAccCheckDashboardGroupResourceExists(s *terraform.State) error {
 
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
-		case "signalfx_time_chart", "signalfx_list_chart", "signalfx_single_value_chart", "signalfx_heatmap_chart", "signalfx_text_chart":
+		case "signalfx_time_chart", "signalfx_list_chart", "signalfx_single_value_chart", "signalfx_heatmap_chart", "signalfx_text_chart", "signalfx_event_feed_chart":
 			chart, err := client.GetChart(rs.Primary.ID)
 			if chart.Id != rs.Primary.ID || err != nil {
-				return fmt.Errorf("Error finding time chart %s: %s", rs.Primary.ID, err)
+				return fmt.Errorf("Error finding chart %s: %s", rs.Primary.ID, err)
 			}
 		case "signalfx_dashboard":
 			dash, err := client.GetDashboard(rs.Primary.ID)
@@ -373,10 +379,10 @@ func testAccDashboardGroupDestroy(s *terraform.State) error {
 	client, _ := sfx.NewClient(os.Getenv("SFX_AUTH_TOKEN"))
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
-		case "signalfx_time_chart", "signalfx_list_chart", "signalfx_single_value_chart", "signalfx_heatmap_chart", "signalfx_text_chart":
+		case "signalfx_time_chart", "signalfx_list_chart", "signalfx_single_value_chart", "signalfx_heatmap_chart", "signalfx_text_chart", "signalfx_event_feed_chart":
 			chart, _ := client.GetChart(rs.Primary.ID)
 			if chart.Id != "" {
-				return fmt.Errorf("Found deleted time chart %s", rs.Primary.ID)
+				return fmt.Errorf("Found deleted chart %s", rs.Primary.ID)
 			}
 		case "signalfx_dashboard":
 			dash, _ := client.GetDashboard(rs.Primary.ID)

--- a/signalfx/resource_dashboard_and_friends_test.go
+++ b/signalfx/resource_dashboard_and_friends_test.go
@@ -271,6 +271,11 @@ resource "signalfx_event_feed_chart" "myeventfeed0" {
 	name = "Interesting Events"
 	description = "Lorem ipsum dolor sit fartet"
 	program_text = "A = events(eventType='Fart Testing').publish(label='A')"
+
+	viz_options {
+			label = "A"
+			color = "orange"
+	}
 }
 
 resource "signalfx_dashboard_group" "mydashboardgroup0" {


### PR DESCRIPTION
# Summary

Add new `resource_event_feed_chart`.

# Motivation

Fixes #27

# Notes
This is currently undocumented in SignalFx's API docs. That will likely change, and this might as well. There's definitely some settings on the viz that can be set here.