### PR TITLE
Add refreshInterval to heatmaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Added acceptance tests for Integration and Detector.
 * [New resource](https://github.com/signalfx/terraform-provider-signalfx/pull/35) `signalfx_event_feed_chart` for [Event Feed charts](https://docs.signalfx.com/en/latest/dashboards/dashboard-add-info.html#adding-an-event-feed-chart-to-a-dashboard).
 * [New resources](https://github.com/signalfx/terraform-provider-signalfx/pull/34) `resource_pagerduty_integration` and `resource_gcp_integration` which completes the trifecta needed to get rid of `resource_integration` in the future.
+* [Added 'refresh_interval' property to Heatmap](https://github.com/signalfx/terraform-provider-signalfx/pull/45). Thanks to [clayembry](https://github.com/clayembry) for flagging.
 
 ## Fixed
 

--- a/signalfx/resource_signalfx_heatmap_chart.go
+++ b/signalfx/resource_signalfx_heatmap_chart.go
@@ -43,6 +43,11 @@ func heatmapChartResource() *schema.Resource {
 				Description:  "How long (in seconds) to wait for late datapoints",
 				ValidateFunc: validateMaxDelayValue,
 			},
+			"refresh_interval": &schema.Schema{
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "How often (in seconds) to refresh the values of the heatmap",
+			},
 			"disable_sampling": &schema.Schema{
 				Type:        schema.TypeBool,
 				Optional:    true,
@@ -217,9 +222,13 @@ func getHeatmapOptionsChart(d *schema.ResourceData) map[string]interface{} {
 	if val, ok := d.GetOk("max_delay"); ok {
 		programOptions["maxDelay"] = val.(int) * 1000
 	}
+
 	programOptions["disableSampling"] = d.Get("disable_sampling").(bool)
 	viz["programOptions"] = programOptions
 
+	if refreshInterval, ok := d.GetOk("refresh_interval"); ok {
+		viz["refreshInterval"] = refreshInterval.(int) * 1000
+	}
 	if groupByOptions, ok := d.GetOk("group_by"); ok {
 		viz["groupBy"] = groupByOptions.([]interface{})
 	}


### PR DESCRIPTION
# Summary

Adds `refreshInterval` property to Heatmaps.

# Motivation

There is an error in the docs that omits `option.type.Heatmap` from [Create Chart](https://developers.signalfx.com/charts_reference.html#operation/Create%20Single%20Chart), but includes it in [Update Chart](https://developers.signalfx.com/charts_reference.html#tag/Update-Single-Chart). This caused me to misdiagnose #41 and say it was on purpose. Boo!

I've filed an internal ticket for the docs and this fixes the missing property.

/cc @clayembry