### PR TITLE
Deprecate some stuff leading up to 4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,16 @@
 # 4.0.0 (Unreleased)
 
-## Added
+# 3.4.0 (Unreleased)
 
-## Fixed
+NOTES:
 
-## Removed
-
-## Changed
+* resource/dashboard: `tags` has been deprecated
+* resource/dashboard: `grid.start_row` has been deprecated
+* resource/dashboard: `grid.start_column` has been deprecated
+* resource/dashboard: `column.start_row` has been deprecated
+* resource/detector: `tags` has been deprecated
+* resource/event_feed_chart: `viz_options` has been deprecated
+* resource/time_chart: `tags` has been deprecated
 
 # 3.3.0 (2019-06-28)
 

--- a/signalfx/resource_signalfx_dashboard.go
+++ b/signalfx/resource_signalfx_dashboard.go
@@ -66,6 +66,7 @@ func dashboardResource() *schema.Resource {
 			"tags": &schema.Schema{
 				Type:        schema.TypeList,
 				Optional:    true,
+				Deprecated:  "signalfx_dashboard.tags is being removed in the next release",
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: "Tags associated with the dashboard",
 			},
@@ -119,12 +120,14 @@ func dashboardResource() *schema.Resource {
 						},
 						"start_row": &schema.Schema{
 							Type:        schema.TypeInt,
+							Deprecated:  "signalfx_dashboard.grid.start_row is being removed in the next release",
 							Optional:    true,
 							Description: "Starting row number for the grid",
 							Default:     0,
 						},
 						"start_column": &schema.Schema{
 							Type:        schema.TypeInt,
+							Deprecated:  "signalfx_dashboard.grid.start_column is being removed in the next release",
 							Optional:    true,
 							Description: "Starting column number for the grid",
 							Default:     0,
@@ -164,6 +167,7 @@ func dashboardResource() *schema.Resource {
 						},
 						"start_row": &schema.Schema{
 							Type:        schema.TypeInt,
+							Deprecated:  "signalfx_dashboard.column.start_row is being removed in the next release",
 							Optional:    true,
 							Description: "Starting row number for the column",
 							Default:     0,

--- a/signalfx/resource_signalfx_detector.go
+++ b/signalfx/resource_signalfx_detector.go
@@ -85,6 +85,7 @@ func detectorResource() *schema.Resource {
 			},
 			"tags": &schema.Schema{
 				Type:        schema.TypeList,
+				Deprecated:  "signalfx_detector.tags is being removed in the next release",
 				Optional:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: "Tags associated with the detector",

--- a/signalfx/resource_signalfx_event_feed_chart.go
+++ b/signalfx/resource_signalfx_event_feed_chart.go
@@ -33,6 +33,7 @@ func eventFeedChartResource() *schema.Resource {
 			},
 			"viz_options": &schema.Schema{
 				Type:        schema.TypeSet,
+				Deprecated:  "signalfx_event_feed_chart.viz_options is being removed in the next release",
 				Optional:    true,
 				Description: "Plot-level customization options, associated with a publish statement",
 				Elem: &schema.Resource{

--- a/signalfx/resource_signalfx_time_chart.go
+++ b/signalfx/resource_signalfx_time_chart.go
@@ -349,6 +349,7 @@ func timeChartResource() *schema.Resource {
 			},
 			"tags": &schema.Schema{
 				Type:        schema.TypeList,
+				Deprecated:  "signalfx_time_chart.tags is being removed in the next release",
 				Optional:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: "Tags associated with the chart",


### PR DESCRIPTION
This deprecates some stuff in the lead up to 4.0, which is pretty much #44 