### PR TITLE
Bump dep on sfx-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/hashstructure v1.0.0 // indirect
 	github.com/signalfx/golib v2.4.0+incompatible // indirect
-	github.com/signalfx/signalfx-go v0.0.0-20190627212220-0288248cbbb3
+	github.com/signalfx/signalfx-go v0.0.0-20190702151806-c1299cf52ff4
 	github.com/smartystreets/assertions v1.0.0 // indirect
 	github.com/stretchr/testify v1.3.0
 	github.com/zclconf/go-cty v0.0.0-20190212192503-19dda139b164 // indirect

--- a/go.sum
+++ b/go.sum
@@ -275,8 +275,8 @@ github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAm
 github.com/signalfx/golib v2.3.4+incompatible/go.mod h1:nWYefOwlUKWm/SpN/LgVSBnyH1T9NpT1ANlmgRIi1Cs=
 github.com/signalfx/golib v2.4.0+incompatible h1:VtCORl7AdhkCIy3rS0m3WLpcNmqGcWosXQ9xX2QepXw=
 github.com/signalfx/golib v2.4.0+incompatible/go.mod h1:nWYefOwlUKWm/SpN/LgVSBnyH1T9NpT1ANlmgRIi1Cs=
-github.com/signalfx/signalfx-go v0.0.0-20190627212220-0288248cbbb3 h1:Xops4sil25jo3TkA4xewOlatTpDM9qTsIsmno8Uus78=
-github.com/signalfx/signalfx-go v0.0.0-20190627212220-0288248cbbb3/go.mod h1:0Q0eueMWMC8r+jq+LJIGrspzvLF+hpWO9cggHlSpwVs=
+github.com/signalfx/signalfx-go v0.0.0-20190702151806-c1299cf52ff4 h1:+af3FGmuDsSPnt6SiWb/TE4KPhdP+d4CmMrNYVjyqPw=
+github.com/signalfx/signalfx-go v0.0.0-20190702151806-c1299cf52ff4/go.mod h1:0Q0eueMWMC8r+jq+LJIGrspzvLF+hpWO9cggHlSpwVs=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/assertions v0.0.0-20190116191733-b6c0e53d7304/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/assertions v1.0.0 h1:UVQPSSmc3qtTi+zPPkCXvZX9VvW/xT/NsRvKfwY81a8=


### PR DESCRIPTION
# Summary

Bump dependency on signalfx-go.

# Motivation

[This PR for signalfx-go](https://github.com/signalfx/signalfx-go/pull/22) ensures that we can deal with the possibility of a dashboard with single-value `source.value`. This is unlikely to happen from any material made by this provider, since it deals in arrays. But when we deal with #36 we might encounter them.

