### PR TITLE
Fix TeamEmail and Team notification docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ IMPROVEMENTS:
 * resource/list_chart: Parameters for `sort_by` have had documentation improved. [#64](https://github.com/signalfx/terraform-provider-signalfx/pull/64)
 * resource/time_chart: `axes_precision` property now has documentation. [#55](https://github.com/signalfx/terraform-provider-signalfx/issues/55)
 * resource/dashboard: Corrected name of `filter.negated` which was incorrectly documented as `not`. [#52](https://github.com/signalfx/terraform-provider-signalfx/issues/52)
+* resource/detector: Added examples for `Team` and `TeamEmail` notifications. [#50](https://github.com/signalfx/terraform-provider-signalfx/issues/50)
 
 BACKWARDS INCOMPATIBILITIES:
 

--- a/website/docs/r/detector.html.markdown
+++ b/website/docs/r/detector.html.markdown
@@ -74,6 +74,22 @@ notifications = ["PagerDuty,credentialId"]
 notifications = ["Slack,channel"]
 ```
 
+### Team
+
+Sends [notifications to a team](https://docs.signalfx.com/en/latest/managing/teams/team-notifications.html).
+
+```
+notifications = ["Team,teamId"]
+```
+
+### Team
+
+Sends an email to every member of a team.
+
+```
+notifications = ["TeamEmail,teamId"]
+```
+
 ### Webhook
 
 ```


### PR DESCRIPTION
# Summary

Adds documentation for notifications of type `Team` and `TeamEmail`.

# Motivation

I was unsure if the `TeamEmail` implementation matched what we had in the docs. It didn't, but that's cuz there was a bug in the docs! After looking I realized we had no examples of these two notification types so I added them.

Fixes #50 