### PR TITLE
Add color_scale to list_chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ FEATURES:
 * provider: Added various utility methods for color name and index lookups
 * resource/event_feed_chart: Add properties `time_range`, `start_time`, and `end_time`.
 * resource/list_chart: now supports `legend_options_fields`.
-* resource/list_chart: now support `color_scale` and it's sub-fields
+* resource/list_chart: now support `color_scale` and it's sub-fields [#76](https://github.com/signalfx/terraform-provider-signalfx/pull/76)
 * resource/time_chart: now supports `timezone`, thanks [zimingw](https://github.com/zimingw). [#60](https://github.com/signalfx/terraform-provider-signalfx/pull/60) and [#68](https://github.com/signalfx/terraform-provider-signalfx/pull/68)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@ FEATURES:
 * provider: Added various utility methods for color name and index lookups
 * resource/event_feed_chart: Add properties `time_range`, `start_time`, and `end_time`.
 * resource/list_chart: now supports `legend_options_fields`.
+* resource/list_chart: now support `color_scale` and it's sub-fields
 * resource/time_chart: now supports `timezone`, thanks [zimingw](https://github.com/zimingw). [#60](https://github.com/signalfx/terraform-provider-signalfx/pull/60) and [#68](https://github.com/signalfx/terraform-provider-signalfx/pull/68)
+
 
 BUG FIXES:
 

--- a/signalfx/resource_signalfx_list_chart_test.go
+++ b/signalfx/resource_signalfx_list_chart_test.go
@@ -108,6 +108,12 @@ func TestAccCreateUpdateListChart(t *testing.T) {
 					resource.TestCheckResourceAttr("signalfx_list_chart.mychartLX", "legend_options_fields.#", "1"),
 					resource.TestCheckResourceAttr("signalfx_list_chart.mychartLX", "legend_options_fields.0.enabled", "false"),
 					resource.TestCheckResourceAttr("signalfx_list_chart.mychartLX", "legend_options_fields.0.property", "collector"),
+
+					resource.TestCheckResourceAttr("signalfx_list_chart.mychartLX", "color_scale.#", "2"),
+					resource.TestCheckResourceAttr("signalfx_list_chart.mychartLX", "color_scale.690432474.color", "cerise"),
+					resource.TestCheckResourceAttr("signalfx_list_chart.mychartLX", "color_scale.690432474.gt", "40"),
+					resource.TestCheckResourceAttr("signalfx_list_chart.mychartLX", "color_scale.761948173.color", "vivid_yellow"),
+					resource.TestCheckResourceAttr("signalfx_list_chart.mychartLX", "color_scale.761948173.lte", "40"),
 				),
 			},
 			// Update Everything

--- a/signalfx/resource_signalfx_list_chart_test.go
+++ b/signalfx/resource_signalfx_list_chart_test.go
@@ -20,14 +20,24 @@ resource "signalfx_list_chart" "mychartLX" {
   data('cpu.total.idle').publish(label='CPU Idle')
   EOF
 
-  color_by = "Metric"
   max_delay = 15
   disable_sampling = true
   refresh_interval = 1
   max_precision = 2
   sort_by = "-value"
   unit_prefix = "Binary"
-  secondary_visualization = "Linear"
+  secondary_visualization = "Sparkline"
+
+	color_by = "Scale"
+	color_scale {
+		gt = 40
+		color = "cerise"
+	}
+
+	color_scale {
+		lte = 40
+		color = "vivid_yellow"
+	}
 
 	legend_options_fields {
 		property = "collector"
@@ -45,14 +55,24 @@ resource "signalfx_list_chart" "mychartLX" {
   data('cpu.total.idle').publish(label='CPU Idle')
   EOF
 
-  color_by = "Metric"
   max_delay = 15
   disable_sampling = true
   refresh_interval = 1
   max_precision = 2
   sort_by = "-value"
   unit_prefix = "Binary"
-  secondary_visualization = "Linear"
+	secondary_visualization = "Sparkline"
+
+	color_by = "Scale"
+	color_scale {
+		gt = 40
+		color = "cerise"
+	}
+
+	color_scale {
+		lte = 40
+		color = "vivid_yellow"
+	}
 
 	legend_options_fields {
 		property = "collector"
@@ -76,12 +96,12 @@ func TestAccCreateUpdateListChart(t *testing.T) {
 					resource.TestCheckResourceAttr("signalfx_list_chart.mychartLX", "description", "Farts"),
 					resource.TestCheckResourceAttr("signalfx_list_chart.mychartLX", "program_text", "data('cpu.total.idle').publish(label='CPU Idle')\n"),
 					resource.TestCheckResourceAttr("signalfx_list_chart.mychartLX", "unit_prefix", "Binary"),
-					resource.TestCheckResourceAttr("signalfx_list_chart.mychartLX", "color_by", "Metric"),
+					resource.TestCheckResourceAttr("signalfx_list_chart.mychartLX", "color_by", "Scale"),
 					resource.TestCheckResourceAttr("signalfx_list_chart.mychartLX", "max_delay", "15"),
 					resource.TestCheckResourceAttr("signalfx_list_chart.mychartLX", "disable_sampling", "true"),
 					resource.TestCheckResourceAttr("signalfx_list_chart.mychartLX", "refresh_interval", "1"),
 					resource.TestCheckResourceAttr("signalfx_list_chart.mychartLX", "max_precision", "2"),
-					resource.TestCheckResourceAttr("signalfx_list_chart.mychartLX", "secondary_visualization", "Linear"),
+					resource.TestCheckResourceAttr("signalfx_list_chart.mychartLX", "secondary_visualization", "Sparkline"),
 					resource.TestCheckResourceAttr("signalfx_list_chart.mychartLX", "sort_by", "-value"),
 
 					// Legend Options

--- a/website/docs/r/list_chart.html.markdown
+++ b/website/docs/r/list_chart.html.markdown
@@ -80,4 +80,10 @@ The following arguments are supported in the resource block:
     * `enabled` True or False depending on if you want the property to be shown or hidden.
 * `max_precision` - (Optional) Maximum number of digits to display when rounding values up or down.
 * `secondary_visualization` - (Optional) The type of secondary visualization. Can be `None`, `Radial`, `Linear`, or `Sparkline`. If unset, the SignalFx default is used (`Sparkline`).
+* `color_scale` - (Optional. `color_by` must be `"Scale"`) Single color range including both the color to display for that range and the borders of the range. Example: `[{ gt = 60, color = "blue" }, { lte = 60, color = "yellow" }]`. Look at this [link](https://docs.signalfx.com/en/latest/charts/chart-options-tab.html).
+    * `gt` - (Optional) Indicates the lower threshold non-inclusive value for this range.
+    * `gte` - (Optional) Indicates the lower threshold inclusive value for this range.
+    * `lt` - (Optional) Indicates the upper threshold non-inculsive value for this range.
+    * `lte` - (Optional) Indicates the upper threshold inclusive value for this range.
+    * `color` - (Required) The color range to use. Must be either gray, blue, navy, orange, yellow, magenta, purple, violet, lilac, green, aquamarine.
 * `sort_by` - (Optional) The property to use when sorting the elements. Use `value` if you want to sort by value. Must be prepended with `+` for ascending or `-` for descending (e.g. `-foo`). Note there are some special values for some of the options provided in the UX: `"value"` for Value, `"sf_originatingMetric"` for Metric, and `"sf_metric"` for plot.


### PR DESCRIPTION
# Summary

Adds `color_scale` and it's sub-options to resource/list_chart

# Motivation

Was asked for in #62 